### PR TITLE
Update references to EGI-Foundation, and use EGI-Federation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,6 @@ jobs:
         with:
           # Use a personal token configured as a repository-specific secret
           personal_token: ${{ steps.generate-token.outputs.token }}
-          external_repository: EGI-Foundation/EGI-Foundation.github.io
+          external_repository: EGI-Federation/EGI-Federation.github.io
           cname: docs.egi.eu
           publish_branch: master

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # EGI documentation
 
-[![Build Status](https://github.com/EGI-Foundation/documentation/workflows/Build%20documentation/badge.svg)](https://github.com/EGI-Foundation/documentation/actions)
+[![Build Status](https://github.com/EGI-Federation/documentation/workflows/Build%20documentation/badge.svg)](https://github.com/EGI-Federation/documentation/actions)
 
-[![Deploy Status](https://github.com/EGI-Foundation/documentation/workflows/Deploy%20to%20GitHub%20pages/badge.svg)](https://github.com/EGI-Foundation/documentation/actions)
+[![Deploy Status](https://github.com/EGI-Federation/documentation/workflows/Deploy%20to%20GitHub%20pages/badge.svg)](https://github.com/EGI-Federation/documentation/actions)
 
 Sources files used to build [EGI documentation](https://docs.egi.eu).
 
@@ -11,7 +11,7 @@ Sources files used to build [EGI documentation](https://docs.egi.eu).
 - The static site is
   [deployed on GitHub](https://gohugo.io/hosting-and-deployment/hosting-on-github/)
   using a dedicated
-  [GitHub repository](https://github.com/EGI-Foundation/EGI-Foundation.github.io).
+  [GitHub repository](https://github.com/EGI-Federation/EGI-Federation.github.io).
 
 > If you are interested in contributing please check the
 > [Contributing Guide](https://docs.egi.eu/about/contributing/).
@@ -75,6 +75,6 @@ git commit themes/docsy -m 'Update theme'
 
 ## Deployment to the EGI organisation pages
 
-[GitHub Actions](https://github.com/EGI-Foundation/documentation/tree/master/.github/workflows)
+[GitHub Actions](https://github.com/EGI-Federation/documentation/tree/master/.github/workflows)
 will automatically deploy a new version when a PR is merged to master,
 it will then be availalbe at [https://docs.egi.eu](https://docs.egi.eu).

--- a/config.toml
+++ b/config.toml
@@ -75,7 +75,7 @@ copyright = "EGI Foundation"
 privacy_policy = "https://www.egi.eu/privacy-policy/"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/EGI-Foundation/documentation"
+github_repo = "https://github.com/EGI-Federation/documentation"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 # github_project_repo = "https://github.com/google/docsy"
 
@@ -111,8 +111,8 @@ navbar_logo = true
 [params.ui.feedback]
 enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
-yes = 'Glad to hear it! Please <a href="https://github.com/EGI-Foundation/documentation/issues/new">tell us how we can improve</a>.'
-no = 'Sorry to hear that. Please <a href="https://github.com/EGI-Foundation/documentation/issues/new">tell us how we can improve</a>.'
+yes = 'Glad to hear it! Please <a href="https://github.com/EGI-Federation/documentation/issues/new">tell us how we can improve</a>.'
+no = 'Sorry to hear that. Please <a href="https://github.com/EGI-Federation/documentation/issues/new">tell us how we can improve</a>.'
 
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
@@ -134,7 +134,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/EGI-Foundation/docu
 #  Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
   name = "GitHub"
-  url = "https://github.com/EGI-Foundation"
+  url = "https://github.com/EGI-Federation"
   icon = "fab fa-github"
   desc = "Development takes place here!"
 # [[params.links.developer]]
@@ -150,7 +150,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/EGI-Foundation/docu
 # XXX Maybe useful to add back this somewhere
 # [[menu.shortcuts]]
 # name = "<i class='fa fa-cloud-download'></i> <label>Download</label>"
-# url = "https://github.com/EGI-Foundation/EGI-Foundation.github.io/archive/master.zip"
+# url = "https://github.com/EGI-Federation/EGI-Federation.github.io/archive/master.zip"
 # weight = 11
 
 [markup]

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -11,7 +11,7 @@ description: "Documentation related to EGI activities"
   <p class="lead mt-5">
     This website hosts the first version of the new EGI documentation.<br />
     It will be further improved with more sections in the coming months.<br />
-    <a href="https://github.com/EGI-Foundation/documentation/issues/new">Your
+    <a href="https://github.com/EGI-Federation/documentation/issues/new">Your
     feedback and suggestions are welcome!</a>
   </p>
 
@@ -67,7 +67,7 @@ The EGI Federation is supporting lots of different user communities.
 {{% blocks/feature icon="fab fa-github" title="Contributions welcome!"
     url="https://docs.egi.eu/about/contributing" %}}
 <!-- markdown-link-check-enable-->
-We do a [Pull Request](https://github.com/EGI-Foundation/documentation/pulls)
+We do a [Pull Request](https://github.com/EGI-Federation/documentation/pulls)
 contributions workflow on **GitHub**. New users are always welcome!
 {{% /blocks/feature %}}
 

--- a/content/en/about/contributing/_index.md
+++ b/content/en/about/contributing/_index.md
@@ -22,7 +22,7 @@ contribute are also welcome.
 ## Feedback and Questions
 
 If you wish to discuss anything related to the project, please open a
-[GitHub issue](https://github.com/EGI-Foundation/documentation/issues/new) or
+[GitHub issue](https://github.com/EGI-Federation/documentation/issues/new) or
 start a topic on the [EGI Community Forum](https://community.egi.eu). The
 maintainers will sometimes move issues off from GitHub to the community forum if
 it is thought that longer, more open-ended discussion would be beneficial,
@@ -49,7 +49,7 @@ made in two ways:
 {{% alert title="Note" color="info" %}} If you need to discuss your change
 beforehand, like for adding a new section of if you have any doubts, you can ask
 the maintainers it by creating a
-[GitHub issue](https://github.com/EGI-Foundation/documentation/issues/new).
+[GitHub issue](https://github.com/EGI-Federation/documentation/issues/new).
 {{% /alert %}}
 
 Before proposing a contribution via the so-called Pull Request (PR), ideally
@@ -59,7 +59,7 @@ contributions.
 
 1. Fork the project if you have not, and commit changes to a git branch.
    Documentation on building the documentation locally is available in the
-   [README.md](https://github.com/EGI-Foundation/documentation/blob/master/README.md)
+   [README.md](https://github.com/EGI-Federation/documentation/blob/master/README.md)
 1. Create a GitHub Pull Request for your change, following the instructions in
    the Pull Request template.
 1. Perform a [Code Review](#code-review-process) with the maintainers on the

--- a/content/en/about/contributing/git/_index.md
+++ b/content/en/about/contributing/git/_index.md
@@ -39,7 +39,7 @@ In order to be able to send code update to the repository you need to:
 
 In this process three git repositories are used:
 
-- The _upstream_ repository: EGI-Foundation/documentation
+- The _upstream_ repository: EGI-Federation/documentation
 - Your fork, also named _origin_: <your_username>/documentation
 - A local clone of your fork, containing references to your fork, its _origin_
   and to the _upstream_ repository
@@ -96,7 +96,7 @@ This command will fork the repository to your GitHub account and clone a local
 copy for you to work with.
 
 ```sh
-gh repo fork EGI-Foundation/documentation
+gh repo fork EGI-Federation/documentation
 ```
 
 ### Cloning the fork
@@ -116,15 +116,15 @@ the origin and upstream repositories.
 $ git remote -v
 origin  git@github.com:<your_username>/documentation (fetch)
 origin  git@github.com:<your_username>/documentation (push)
-upstream        git@github.com:EGI-Foundation/documentation.git (fetch)
-upstream        git@github.com:EGI-Foundation/documentation.git (push)
+upstream        git@github.com:EGI-Federation/documentation.git (fetch)
+upstream        git@github.com:EGI-Federation/documentation.git (push)
 ```
 
 ## Running the site locally
 
 The documentation webiste is built from the source files using
 [Hugo](https://gohugo.io/). The repository
-[README](https://github.com/EGI-Foundation/documentation/blob/master/README.md)
+[README](https://github.com/EGI-Federation/documentation/blob/master/README.md)
 can be used as a reference for building instructions.
 
 ### Requirements

--- a/content/en/about/contributing/style/_index.md
+++ b/content/en/about/contributing/style/_index.md
@@ -58,7 +58,7 @@ Configuration is provided in `.prettierrc`, options can be set as follow:
 ```
 
 When a Pull Request is received, the proposed changes are checked using
-[various linters](https://github.com/EGI-Foundation/documentation/tree/master/.github/workflows).
+[various linters](https://github.com/EGI-Federation/documentation/tree/master/.github/workflows).
 
 ## Adding exceptions for style violations
 

--- a/content/en/providers/cloud-compute/openstack/_index.md
+++ b/content/en/providers/cloud-compute/openstack/_index.md
@@ -1100,7 +1100,7 @@ volumes.
 Information discovery provides a real-time view about the actual images and
 flavors available at the OpenStack for the federation users. It runs as a
 single python application
-[cloud-info-provider](https://github.com/EGI-Foundation/cloud-info-provider)
+[cloud-info-provider](https://github.com/EGI-Federation/cloud-info-provider)
 that pushes information through the [Argo Messaging Service
 (AMS)](https://argoeu.github.io/guides/messaging/)
 
@@ -1118,8 +1118,8 @@ entry for the `org.openstack.nova`.
 EGI can manage the operation of the `cloud-info-provider` for the site so you
 don't need to do it. In order for your site to be included in the centrally
 operated `cloud-info-provider`, you need to create a Pull Request at the
-[EGI-Foundation/fedcloud-catchall-operations
-repository](https://github.com/EGI-Foundation/fedcloud-catchall-operations/)
+[EGI-Federation/fedcloud-catchall-operations
+repository](https://github.com/EGI-Federation/fedcloud-catchall-operations/)
 adding your site configuration in the `sites` directory with a file like this:
 
 ```yaml
@@ -1142,11 +1142,11 @@ publishing information.
 
 You can operate by yourself the `cloud-info-provider`. The software can be
 obtained as RPMs, debs and python packages from the [GitHub releases
-page](https://github.com/EGI-Foundation/cloud-info-provider/releases).
+page](https://github.com/EGI-Federation/cloud-info-provider/releases).
 
 The `cloud-info-provider` needs a configuration file where your site is
 described, see the [sample OpenStack
-configuration](https://github.com/EGI-Foundation/cloud-info-provider/blob/master/etc/sample.openstack.yaml)
+configuration](https://github.com/EGI-Federation/cloud-info-provider/blob/master/etc/sample.openstack.yaml)
 for the required information. The authentication parameters for your local
 OpenStack and the AMS are passed as command line options:
 

--- a/content/en/providers/notebooks/architecture/_index.md
+++ b/content/en/providers/notebooks/architecture/_index.md
@@ -19,9 +19,9 @@ functionality:
 - CA authority to allocate recognised certificates for the HTTPS server
 - [Prometheus](https://prometheus.io/) for monitoring resource consumption.
 - Specific EGI hooks for
-  [monitoring](https://github.com/EGI-Foundation/egi-notebooks-monitoring),
-  [accounting](https://github.com/EGI-Foundation/egi-notebooks-accounting) and
-  [backup](https://github.com/EGI-Foundation/egi-notebooks-backup).
+  [monitoring](https://github.com/EGI-Federation/egi-notebooks-monitoring),
+  [accounting](https://github.com/EGI-Federation/egi-notebooks-accounting) and
+  [backup](https://github.com/EGI-Federation/egi-notebooks-backup).
 - VO-Specific storage/Big data facilities or any pluggable tools into the
   notebooks environment can be added to community specific instances.
 
@@ -129,7 +129,7 @@ will allow to get up-to-date valid credentials as needed.
 
 This is Work in progress, expect changes! {{% /alert %}}
 
-[Accounting module](https://github.com/EGI-Foundation/egi-notebooks-accounting)
+[Accounting module](https://github.com/EGI-Federation/egi-notebooks-accounting)
 generates VM-like accounting records for each of the notebooks started at the
 service. It\'s available as a
 [helm chart](https://egi-foundation.github.io/egi-notebooks-chart/) that can be
@@ -147,7 +147,7 @@ ssm:
 
 ### Monitoring
 
-[Monitoring](https://github.com/EGI-Foundation/egi-notebooks-monitoring) is
+[Monitoring](https://github.com/EGI-Federation/egi-notebooks-monitoring) is
 performed by trying to execute a user notebook every hour. This is accomplished
 by registering a new service in the hub that has admin permissions. Monitoring
 is then deployed as a

--- a/content/en/providers/notebooks/architecture/_index.md
+++ b/content/en/providers/notebooks/architecture/_index.md
@@ -132,7 +132,7 @@ This is Work in progress, expect changes! {{% /alert %}}
 [Accounting module](https://github.com/EGI-Federation/egi-notebooks-accounting)
 generates VM-like accounting records for each of the notebooks started at the
 service. It\'s available as a
-[helm chart](https://egi-foundation.github.io/egi-notebooks-chart/) that can be
+[helm chart](https://EGI-Federation.github.io/egi-notebooks-chart/) that can be
 deployed in the same namespace as the JupyterHub chart. The only needed
 configuration for the chart is an IGTF-recognised certificate for the host
 registered in GOCDB as accounting.
@@ -151,7 +151,7 @@ ssm:
 performed by trying to execute a user notebook every hour. This is accomplished
 by registering a new service in the hub that has admin permissions. Monitoring
 is then deployed as a
-[helm chart](https://egi-foundation.github.io/egi-notebooks-chart/) that must be
+[helm chart](https://EGI-Federation.github.io/egi-notebooks-chart/) that must be
 deployed in the same namespace as the JupyterHub chart. Configuration of
 JupyterHub must include this section:
 
@@ -175,7 +175,7 @@ service:
 
 Our service relies on custom images for the hub and the single-user notebooks.
 Dockerfiles are available at
-[EGI Notebooks images](https://github.com/EGI-foundation/egi-notebooks-images)
+[EGI Notebooks images](https://github.com/EGI-Federation/egi-notebooks-images)
 git repository and automatically build for every commit pushed to the repo to
 [eginotebooks @ dockerhub](https://hub.docker.com/u/eginotebooks).
 

--- a/content/en/users/cloud-compute/auth/_index.md
+++ b/content/en/users/cloud-compute/auth/_index.md
@@ -102,7 +102,7 @@ access to several different projects within that provider (a project can be
 considered equivalent to a VO allocation). In order to discover which projects
 are available you can do that using the Keystone API.
 
-You can use the [`egicli`](https://github.com/EGI-Foundation/egicli) to simplify
+You can use the [`egicli`](https://github.com/EGI-Federation/egicli) to simplify
 the discovery of projects. First, define these variables in your environment:
 
 - `CHECKIN_CLIENT_ID`: Your Check-in client id (get it from

--- a/content/en/users/cloud-compute/auth/_index.md
+++ b/content/en/users/cloud-compute/auth/_index.md
@@ -167,7 +167,7 @@ of X.509 certificates should be limited to legacy applications. {{% /alert %}}
 [VOMS](https://italiangrid.github.io/voms/index.html) uses X.509 proxies
 extended with VO information for authentication and authorisation on the
 providers. You can learn about X.509 certificates and VOMS in the
-[Check-in documentation](../../check-in/voms).
+[Check-in documentation](../../check-in/vos/voms).
 
 ### VOMS configuration
 

--- a/content/en/users/cloud-compute/federation/_index.md
+++ b/content/en/users/cloud-compute/federation/_index.md
@@ -153,7 +153,7 @@ service types are avialable:
 All providers **must** enter cloud service endpoints to GOCDB to enable
 integration with EGI..
 
-The [Cloud-info-provider](https://github.com/EGI-Foundation/cloud-info-provider)
+The [Cloud-info-provider](https://github.com/EGI-Federation/cloud-info-provider)
 extracts information from the resource centres using their native APIs and
 formats it following Glue, and OGC recommended standard. This information is
 pushed to the Argo Messaging System and consumed by AppDB to provide a central

--- a/content/en/users/cloud-compute/vmi/_index.md
+++ b/content/en/users/cloud-compute/vmi/_index.md
@@ -181,6 +181,6 @@ a hypervisor for the creation of the images and guarantees identical results
 under different platforms and providers.
 
 Check the
-[fedcloud-vmi-templates github repo](https://github.com/EGI-Foundation/fedcloud-vmi-templates)
+[fedcloud-vmi-templates github repo](https://github.com/EGI-Federation/fedcloud-vmi-templates)
 with all the packer recipes used to build our images and re-use them as needed
 for your images.

--- a/content/en/users/cloud-container-compute/k8s.md
+++ b/content/en/users/cloud-container-compute/k8s.md
@@ -17,7 +17,7 @@ Before getting your kubernetes cluster deployed, you need to get access to the
 Cloud Compute service, check the
 [Authentication and Authorisation guide](../cloud-compute/auth) for more
 information. You should also get
-[`egicli`](https://github.com/EGI-Foundation/egicli/) installed to get EC3
+[`egicli`](https://github.com/EGI-Federation/egicli/) installed to get EC3
 templates needed to start deployment.
 
 Your kubernetes deployment needs to be performed at an specific provider (site)

--- a/content/en/users/notebooks/faq/_index.md
+++ b/content/en/users/notebooks/faq/_index.md
@@ -28,6 +28,6 @@ stopped (automatically after 1 hour of inactivity)! {{% /alert %}}
 Yes! Just let us know what are your needs. You can contact us via:
 
 - Opening a ticket in the [EGI Helpdesk](https://ggus.eu), or
-- Creating a [Github Issue](https://github.com/EGI-foundation/notebooks/issues)
+- Creating a [Github Issue](https://github.com/EGI-Federation/notebooks/issues)
 
 We will analyse your request and get back to you.

--- a/content/en/users/notebooks/kernels/_index.md
+++ b/content/en/users/notebooks/kernels/_index.md
@@ -12,7 +12,7 @@ languages. Each language is available as a different
 
 For the EGI service we have enabled a set of kernels that are automatically
 built from the
-[EGI-Foundation/egi-notebooks-images](https://github.com/EGI-Foundation/egi-notebooks-images)
+[EGI-Federation/egi-notebooks-images](https://github.com/EGI-Foundation/egi-notebooks-images)
 GitHub repository.
 
 ## Python

--- a/content/en/users/notebooks/kernels/_index.md
+++ b/content/en/users/notebooks/kernels/_index.md
@@ -12,7 +12,7 @@ languages. Each language is available as a different
 
 For the EGI service we have enabled a set of kernels that are automatically
 built from the
-[EGI-Federation/egi-notebooks-images](https://github.com/EGI-Foundation/egi-notebooks-images)
+[EGI-Federation/egi-notebooks-images](https://github.com/EGI-Federation/egi-notebooks-images)
 GitHub repository.
 
 ## Python

--- a/content/en/users/notebooks/training/_index.md
+++ b/content/en/users/notebooks/training/_index.md
@@ -107,8 +107,8 @@ We pre-populate your home directory with some sample notebooks to get started,
 below you can find links to other notebooks that we have used in past trainings
 that may be useful to explore the system:
 
-1. [A very basic notebook to get started](https://github.com/EGI-Foundation/training-notebooks-di4r-2018/blob/master/00-first-notebook.ipynb)
-2. [Getting data and doing a simple plot](https://github.com/EGI-Foundation/training-notebooks-climate-change/blob/master/cckp_historical_temperature.ipynb).
-3. [Connect to NOAA\'s GrADS Data Server to plot wind speed](https://github.com/EGI-Foundation/training-notebooks-di4r-2018/blob/master/02-wind-nowcast.ipynb).
-4. [Installing new libraries](https://github.com/EGI-Foundation/training-notebooks-di4r-2018/blob/master/03-customizing.ipynb).
-5. [Interact with Check-in](https://github.com/EGI-Foundation/training-notebooks-di4r-2018/blob/master/04-check-in.ipynb)
+1. [A very basic notebook to get started](https://github.com/EGI-Federation/training-notebooks-di4r-2018/blob/master/00-first-notebook.ipynb)
+2. [Getting data and doing a simple plot](https://github.com/EGI-Federation/training-notebooks-climate-change/blob/master/cckp_historical_temperature.ipynb).
+3. [Connect to NOAA\'s GrADS Data Server to plot wind speed](https://github.com/EGI-Federation/training-notebooks-di4r-2018/blob/master/02-wind-nowcast.ipynb).
+4. [Installing new libraries](https://github.com/EGI-Federation/training-notebooks-di4r-2018/blob/master/03-customizing.ipynb).
+5. [Interact with Check-in](https://github.com/EGI-Federation/training-notebooks-di4r-2018/blob/master/04-check-in.ipynb)

--- a/static/README.md
+++ b/static/README.md
@@ -4,5 +4,5 @@
 > meant to receive Pull Requests.
 >
 > In case you would like to open an issue or Pull Request please do it in the
-> [EGI-Foundation/documentation](https://github.com/EGI-Foundation/documentation)
+> [EGI-Federation/documentation](https://github.com/EGI-Federation/documentation)
 > repository.


### PR DESCRIPTION
Update references to EGI-Foundation, and use EGI-Federation as the GitHub organisation has been renamed.