### PR TITLE
Full git history needed for proper list of changed files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ jobs:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          # Full git history needed to get proper list of changed files
+          fetch-depth: 0
 
       # Runs the Super-Linter action
       # Checking all code base but without throwing errors


### PR DESCRIPTION
Full git history is needed to get a proper list of changed files within `super-linter`.
As documented on https://github.com/github/super-linter#example-connecting-github-action-workflow
Should address issues with super-linter not able to find all the changes.

