### PR TITLE
Update link to EGI glossary

### DIFF
--- a/content/en/about/concepts/_index.md
+++ b/content/en/about/concepts/_index.md
@@ -5,5 +5,6 @@ type: docs
 weight: 20
 ---
 
-{{% pageinfo %}} The EGI Glossary is currently available on the
-[EGI Wiki](https://wiki.egi.eu/wiki/Glossary_V3). {{% /pageinfo %}}
+{{% pageinfo %}} The EGI Glossary is available on the
+[EGI Glossary space](http://go.egi.eu/glossary).
+{{% /pageinfo %}}


### PR DESCRIPTION
Update link to EGI glossary, using the shortlink via go.egi.eu