### PR TITLE
EGI notebooks authorizaton will be limited to vo.notebooks.egi.eu

### DIFF
--- a/content/en/users/notebooks/_index.md
+++ b/content/en/users/notebooks/_index.md
@@ -39,8 +39,12 @@ following added features:
 We offer different service modes depending on your needs:
 
 - Individual users can use the centrally operated service from EGI. Users can
-  login, write and play and re-play notebooks just by
-  [creating an EGI account](../check-in/signup). This instance has limits on the
+  login, write and play and re-play notebooks by:
+
+  1. [creating an EGI account](../check-in/signup)
+  2. [enrolling to the vo.notebooks.egi.eu](https://aai.egi.eu/registry/co_petitions/start/coef:111)
+
+  This instance has limits on the
   amount of resources available for each user (1 CPU core, 1 GB RAM and 10 GB of
   storage). It will also kill inactive sessions after 1 hour.
 

--- a/content/en/users/notebooks/_index.md
+++ b/content/en/users/notebooks/_index.md
@@ -42,7 +42,7 @@ We offer different service modes depending on your needs:
   login, write and play and re-play notebooks by:
 
   1. [creating an EGI account](../check-in/signup)
-  2. [enrolling to the vo.notebooks.egi.eu](https://aai.egi.eu/registry/co_petitions/start/coef:111)
+  2. [enrolling to the vo.notebooks.egi.eu VO](https://aai.egi.eu/registry/co_petitions/start/coef:111)
 
   This instance has limits on the
   amount of resources available for each user (1 CPU core, 1 GB RAM and 10 GB of


### PR DESCRIPTION
# Summary

Update documentation due to EGI Notebooks plan to have limited authorization for the users to vo.notebooks.egi.eu only.

(It can be used as is, but feel free to reword or enhance it as I'm not much writer.)

**Related issue :**
https://jira.egi.eu/browse/IMSCHM-58