### PR TITLE
Do not run deploy step for forks, fixing #277.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,8 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Deploy
+        # Deploy should not run on forks
+        if: ${{ github.repository == 'EGI-Federation/documentation' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           # Use a personal token configured as a repository-specific secret


### PR DESCRIPTION
Do not run deploy step for forks, fixing #277.

Not tested, but done according to https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif and https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context.