### PR TITLE
Added section Getting Started

### DIFF
--- a/content/en/users/_index.md
+++ b/content/en/users/_index.md
@@ -1,27 +1,26 @@
 ---
 title: "User Guides"
 linkTitle: "User Guides"
+description: "Documentation for public EGI services"
 weight: 10
 type: "docs"
-description: >
-  Introduction to EGI FedCloud services
 menu:
   main:
     weight: 10
     pre: <i class='fa fa-user-friends'></i>
 ---
 
-This section contains an [introduction](getting-started) to the
-EGI Federated Cloud (FedCloud) and detailed documentation for
-[public EGI services](https://www.egi.eu/services/), togheter with tutorials
-about how to set up, use, and combine these services.
+This section offers an [introduction](getting-started) to the
+EGI Federated Cloud (FedCloud) and contains detailed documentation for
+[public EGI services](https://www.egi.eu/services/), togheter with
+[tutorials](tutorials) about how to set up, use, and combine these services.
 
 {{% alert title="Note" color="info" %}} See the [Service Providers](../providers)
 section for details on how to integrate identity providers and service providers
-into the EGI FedCloud.
+into EGI FedCloud.
 {{% /alert %}}
 
 ## Request for information
 
-You can ask for more information about the services
-[here](https://www.egi.eu/more-information/).
+You can ask for more information about the public EGI services
+[on our website](https://www.egi.eu/more-information).

--- a/content/en/users/_index.md
+++ b/content/en/users/_index.md
@@ -1,83 +1,27 @@
 ---
-title: "Users"
-linkTitle: "Users"
+title: "User Guides"
+linkTitle: "User Guides"
 weight: 10
 type: "docs"
+description: >
+  Introduction to EGI FedCloud services
 menu:
   main:
     weight: 10
     pre: <i class='fa fa-user-friends'></i>
 ---
 
+This section contains an [introduction](getting-started) to the
+EGI Federated Cloud (FedCloud) and detailed documentation for
+[public EGI services](https://www.egi.eu/services/), togheter with tutorials
+about how to set up, use, and combine these services.
+
+{{% alert title="Note" color="info" %}} See the [Service Providers](../providers)
+section for details on how to integrate identity providers and service providers
+into the EGI FedCloud.
+{{% /alert %}}
+
 ## Request for information
 
 You can ask for more information about the services
 [here](https://www.egi.eu/more-information/).
-
-## Accessing EGI services
-
-You can access EGI services from:
-
-- [EGI Service Catalogue](https://www.egi.eu/services/)
-
-Depending on the access conditions, a service (or an instance of the service)
-may be open for any user, OR it may require requesting access (Ordering). The
-EGI Website together with the connected EGI Marketplace streamlines the process.
-
-## Access conditions
-
-EGI services use the following types of access conditions:
-
-- Wide access: Users can freely access the service. Login may be required but
-  it's possible with various institutional accounts (through EduGAIN) or with a
-  social IDs (e.g. Google). Example: the
-  [open instance of the EGI Notebooks](https://notebooks.egi.eu/)
-- Policy based: Users are granted access based on specific policies defined by
-  the service providers. Access needs to be requested, and will be checked for
-  such services. Example: Compute resources and tools allocated to researchers
-  in medical imaging ([Biomed VO](http://lsgc.org/biomed.html)).
-- Pay-for-use: Services are provided for a fee. Example:
-  [FitSM In-house course](https://www.egi.eu/services/fitsm-training/in-house-training/)
-
-The EGI user community support team handles access requests (orders) for the
-'Policy based' and 'Pay-for-use' access modes. They will respond to the request
-within maximum 5 work days. We normally contact you to have a short
-teleconference meeting to better understand your requirements so we will be able
-to identify resources and services that best match your needs. The meeting
-typically covers two topics:
-
-- What is the background of your request? (scientific domain, partners
-  countries, user bases, pay-for-use or not, etc.).
-- What are the technical details of your use case? (how much CPU cores, RAM per
-  CPU, software services, how long do you need, etc.)
-
-## Capacity allocation
-
-Service access is based on **Virtual Organisations (VOs)**. A Virtual
-Organisation is a group of users and the service providers from the federation
-who allocate capacity for a specific user group. Users are not individually
-enabled in the services but through VOs.
-
-VOs are fully managed by communities allowing them to manage their users and
-grant control access to the services and resources. Usually there is one-to-one
-mapping between research communities and Virtual Organizations (although this is
-not mandatory). Users can also belong to different VOs, e.g. they work with
-different communities. Fine-grained authorisation mechanisms can be enabled
-within a VOs, for example only a subset of the users of a given VO may have
-access rights to manage software applications for that VO.
-
-If we are able to support your case, then there are two options to support you:
-
-1. We grant you access to an existing service, for example to compute resource
-   pools (Virtual Organisations) that already exist in EGI for specific
-   scientific disciplines or for researchers in specific regions. (You can
-   browse these in the
-   [EGI Operations Portal](https://operations-portal.egi.eu/vo/a/list). If there
-   is a suitable VO then we help you join it and use its services.
-
-1. If none of the existing resource pools are suitable for your use case, then
-   we create a new VO for your community. The procedure is as follows:
-   - We will contact our provider and negotiate resources for you.
-   - If there are providers happy to support you, we will sign a Service Level
-     Agreement (SLA) with you
-   - A new VO will be created for your community

--- a/content/en/users/getting-started/_index.md
+++ b/content/en/users/getting-started/_index.md
@@ -4,7 +4,7 @@ linkTitle: "Getting Started"
 type: docs
 weight: 5
 description: >
-  Introduction to EGI FedCloud services
+  Introduction to EGI FedCloud
 ---
 
 ## Overview
@@ -49,10 +49,10 @@ Before users can access a service in the EGI FedCloud, they have to:
 1. Obtain an X.509 certficate, by signing up either with [EGI Check-in](../check-in/signup)
    directly, or with one of the community identity providers from the
    EGI infrastructure.
-1. Enroll into one VO before they can use most of the services, users are not
-   individually granted access to resources.
+1. Enroll into one VO before they can use most of the services, as users are
+   not individually granted access to resources.
 1. Add the certificate to their Internet browser of choice, or import it into
-   the appropriate certificate store on Windows.
+   the appropriate certificate store (on Windows).
 1. If they want to use [command line tools](cli), they will also have to
    obtain OIDC access and refresh tokens.
 

--- a/content/en/users/getting-started/_index.md
+++ b/content/en/users/getting-started/_index.md
@@ -5,7 +5,47 @@ type: docs
 weight: 5
 draft: true
 description: >
-  Introduction to using EGI services
+  Introduction to using EGI Cloud services
 ---
 
-TBD
+## Overview
+
+EGI is a federation of computing and storage resource providers
+united by a mission to support research and innovation.
+
+The resources in the EGI Cloud are offered by
+Infrastructure-as-a-Service (IaaS) [service providers](https://www.egi.eu/federation/egi-federated-cloud/)
+that either run their own [data centers](https://www.egi.eu/federation/data-centres/)
+or rely on community, private and/or public cloud services.
+Most services in the EGI Cloud are based on [OpenStack](openstack) deployments.
+
+On top of the resources in the EGI Cloud, a multitude of academic
+communities (clouds) were created, each with their own virtualised resources
+built around open standards. The development of these academic/researsh clouds
+is driven by requirements of the scientific community.
+
+{{% alert title="Tip" color="info" %}} See also an
+[overview](https://www.egi.eu/federation/egi-federated-cloud/the-egi-federated-cloud-architecture/)
+and a [technical summary](architecture) of the
+EGI Federated Cloud architecture.
+{{% /alert %}}
+
+## Access to resources
+
+...
+
+## Capacity allocation
+
+...
+
+## Access to unused resources
+
+Users in the EGI Cloud may gain opportunistic usage to unused resources.
+These are resources that are not dedicated to the user's organization, but are
+accessible when the research center(s) have some spare resources.
+This enables the most efficient use of resources.
+
+{{% alert title="Note" color="info" %}} Users should not reply on (unused)
+resources not dedicated to their organisations, as access can be lost without
+warning, and data may be lost if not properly backed up.
+{{% /alert %}}

--- a/content/en/users/getting-started/_index.md
+++ b/content/en/users/getting-started/_index.md
@@ -3,7 +3,6 @@ title: "Getting Started"
 linkTitle: "Getting Started"
 type: docs
 weight: 5
-draft: true
 description: >
   Introduction to EGI FedCloud services
 ---

--- a/content/en/users/getting-started/_index.md
+++ b/content/en/users/getting-started/_index.md
@@ -5,7 +5,7 @@ type: docs
 weight: 5
 draft: true
 description: >
-  Introduction to using EGI Cloud services
+  Introduction to using EGI FedCloud services
 ---
 
 ## Overview
@@ -13,13 +13,13 @@ description: >
 EGI is a federation of computing and storage resource providers
 united by a mission to support research and innovation.
 
-The resources in the EGI Cloud are offered by
+The resources in the EGI Federated Cloud (FedCloud) are offered by
 Infrastructure-as-a-Service (IaaS) [service providers](https://www.egi.eu/federation/egi-federated-cloud/)
 that either run their own [data centers](https://www.egi.eu/federation/data-centres/)
 or rely on community, private and/or public cloud services.
 Most services in the EGI Cloud are based on [OpenStack](openstack) deployments.
 
-On top of the resources in the EGI Cloud, a multitude of academic
+On top of the resources in the EGI FedCloud, a multitude of academic
 communities (clouds) were created, each with their own virtualised resources
 built around open standards. The development of these academic/researsh clouds
 is driven by requirements of the scientific community.
@@ -30,17 +30,26 @@ and a [technical summary](architecture) of the
 EGI Federated Cloud architecture.
 {{% /alert %}}
 
-## Access to resources
+## Accessing resources
 
-...
+Access to EGI High Throughput Compute resources is based on
+[Virtual Organisations](../check-in/vos), which
+rely on [X.509 proxy certificates with VOMS extensions](../check-in/vos/voms).
+Users have to enroll into one VO before using the service.
+
+VOs are fully managed by research communities, allowing them to manage their
+users and grant access to their services and resources. This means communities
+can either own their resources and use EGI services to share (federate) them,
+or can use the resources available in the EGI infrastructure for their
+scientific needs.
 
 ## Capacity allocation
 
 ...
 
-## Access to unused resources
+## Unused resources
 
-Users in the EGI Cloud may gain opportunistic usage to unused resources.
+Users in the EGI FedCloud may gain opportunistic usage to unused resources.
 These are resources that are not dedicated to the user's organization, but are
 accessible when the research center(s) have some spare resources.
 This enables the most efficient use of resources.

--- a/content/en/users/getting-started/_index.md
+++ b/content/en/users/getting-started/_index.md
@@ -54,7 +54,7 @@ These are resources that are not dedicated to the user's organization, but are
 accessible when the research center(s) have some spare resources.
 This enables the most efficient use of resources.
 
-{{% alert title="Note" color="info" %}} Users should not reply on (unused)
-resources not dedicated to their organisations, as access can be lost without
+{{% alert title="Note" color="info" %}} Users should not rely on (unused)
+resources not dedicated to their organisation, as access can be revoked without
 warning, and data may be lost if not properly backed up.
 {{% /alert %}}

--- a/content/en/users/getting-started/_index.md
+++ b/content/en/users/getting-started/_index.md
@@ -5,7 +5,7 @@ type: docs
 weight: 5
 draft: true
 description: >
-  Introduction to using EGI FedCloud services
+  Introduction to EGI FedCloud services
 ---
 
 ## Overview
@@ -32,20 +32,87 @@ EGI Federated Cloud architecture.
 
 ## Accessing resources
 
-Access to EGI High Throughput Compute resources is based on
-[Virtual Organisations](../check-in/vos), which
-rely on [X.509 proxy certificates with VOMS extensions](../check-in/vos/voms).
-Users have to enroll into one VO before using the service.
+Access to resources (services) in EGI FedCloud is based on X.509 certificates.
+The certificates are issued by Certification Authorities (CAs) part of the
+[European Policy Management Authority for Grid Authentication](https://www.eugridpma.org) 
+(EUGridPMA), which is also part of the
+[International Global Trust Federation](https://www.igtf.net) (IGTF).
 
-VOs are fully managed by research communities, allowing them to manage their
-users and grant access to their services and resources. This means communities
-can either own their resources and use EGI services to share (federate) them,
-or can use the resources available in the EGI infrastructure for their
-scientific needs.
+**EGI FedCloud uses [Virtual Organisations](../check-in/vos) (VOs) to control
+access to resources**. VOs are fully managed by research communities, allowing
+communitites to manage their users and grant access to their services and
+resources. This means communities can either own their resources and use EGI
+services to share (federate) them, or can use the resources available in the
+EGI infrastructure for their scientific needs.
+
+Before users can access a service in the EGI FedCloud, they have to:
+
+1. Obtain an X.509 certficate, by signing up either with [EGI Check-in](../check-in/signup)
+   directly, or with one of the community identity providers from the
+   EGI infrastructure.
+1. Enroll into one VO before they can use most of the services, users are not
+   individually granted access to resources.
+1. Add the certificate to their Internet browser of choice, or import it into
+   the appropriate certificate store on Windows.
+1. If they want to use [command line tools](cli), they will also have to
+   obtain OIDC access and refresh tokens.
+
+{{% alert title="Note" color="info" %}} See the [EGI Check-in](../check-in)
+documentation for a detailed description of the Authentication and
+Authorization Infrastructure (AAI) of the EGI Federation, and to gain a
+better understanding of the concepts that act as building blocks for the
+AAI implementation.
+{{% /alert %}}
+
+## Requesting resources
+
+Depending on the access conditions, a service (or an instance of the service)
+may be open for any user, or it may require requesting access (ordering). The
+[EGI Website](https://www.egi.eu/services/) together with the connected
+[EGI Marketplace](https://marketplace.egi.eu) streamlines the ordering process.
+
+EGI services use the following types of access conditions:
+
+- **Wide access** - Users can freely access the service. Login may be required
+  but it's possible with various institutional accounts (through EduGAIN) or
+  with a social IDs (e.g. Google). Example: the
+  [open instance of the EGI Notebooks](https://notebooks.egi.eu/)
+- **Policy based** - Users are granted access based on specific policies
+  defined by the service providers. Access needs to be requested, and will be
+  checked for such services. Example: Compute resources and tools allocated to
+  researchers in medical imaging ([Biomed VO](http://lsgc.org/biomed.html)).
+- **Pay-for-use** - Services are provided for a fee. Example:
+  [FitSM In-house course](https://www.egi.eu/services/fitsm-training/in-house-training/)
+
+The EGI user community support team handles access requests (orders) for the
+_Policy based_ and _Pay-for-use_ access modes. They will respond to the request
+within maximum 5 work days. We normally contact you to have a short
+teleconference meeting to better understand your requirements, and to be able
+to identify resources and services that best match your needs. The meeting
+typically covers two topics:
+
+- **What is the background of your request?** Scientific domain, partner
+  countries, user bases, pay-for-use or not, etc.
+- **What are the technical details of your use case?** How many CPU cores,
+  how much RAM per CPU, which software services, and for how long do you need
+  them, etc.
 
 ## Capacity allocation
 
-...
+When EGI is able to support a request for resources, it can do so in two ways:
+
+1. **We grant you access to an existing service**, for example to compute
+   resource pools (Virtual Organisations) that already exist in EGI for specific
+   scientific disciplines or for researchers in specific regions. (You can
+   browse these in the
+   [EGI Operations Portal](https://operations-portal.egi.eu/vo/a/list). If there
+   is a suitable VO, we help you join it and use its services.
+1. **We create a new VO for your community** when none of the existing resource
+   pools are suitable for your use case. The procedure is as follows:
+   - We will contact our provider and negotiate resources for you
+   - If there are providers happy to support you, we will sign a Service Level
+     Agreement (SLA) with you
+   - A new VO will be created for your community
 
 ## Unused resources
 

--- a/content/en/users/getting-started/architecture/_index.md
+++ b/content/en/users/getting-started/architecture/_index.md
@@ -1,9 +1,10 @@
 ---
-title: "Federation Architecture and Implementation"
+title: "EGI Federation Architecture"
+linkTitle: "Federation Architecture"
 type: docs
-weight: 110
+weight: 10
 description: >
-  The EGI Cloud architecture and technical implementation details
+  The architecture of the EGI Federated Cloud
 ---
 
 The EGI Federated Cloud is a multi-national cloud system that integrates
@@ -33,7 +34,7 @@ research.
 
 ## Federated IaaS
 
-The EGI Federated Cloud Infrastructure as a Service (IaaS) resource centres
+The EGI Federated Cloud Infrastructure-as-a-Service (IaaS) resource centres
 deploy a Cloud Management Framework (CMF) that provide users with an API-based
 service for management of Virtual Machines and associated Block Storage to
 enable persistence and Networks to enable connectivity of the Virtual Machines

--- a/content/en/users/getting-started/architecture/_index.md
+++ b/content/en/users/getting-started/architecture/_index.md
@@ -4,16 +4,16 @@ linkTitle: "Federation Architecture"
 type: docs
 weight: 10
 description: >
-  The architecture of the EGI Federated Cloud
+  The architecture of the EGI FedCloud
 ---
 
-The EGI Federated Cloud is a multi-national cloud system that integrates
-community, private and/or public clouds into a scalable computing platform for
-research. The Federation pools services from a heterogeneous set of cloud
-providers using a single authentication and authorisation framework that allows
-the portability of workloads across multiple providers and enable bringing
-computing to data. The current implementation is focused on IaaS services but
-can be easily applied to PaaS and SaaS layers.
+The EGI Federated Cloud (FedCloud) is a multi-national cloud system that
+integrates community, private and/or public clouds into a scalable computing
+platform for research. The Federation pools services from a heterogeneous set
+of cloud providers using a single authentication and authorisation framework
+that allows the portability of workloads across multiple providers and enable
+bringing computing to data. The current implementation is focused on IaaS
+services but can be easily applied to PaaS and SaaS layers.
 
 Each resource centre of the federated infrastructure operates a _Cloud
 Management Framework (CMF)_ according to its own preferences and constraints and
@@ -40,27 +40,28 @@ service for management of Virtual Machines and associated Block Storage to
 enable persistence and Networks to enable connectivity of the Virtual Machines
 among themselves and third party resources.
 
-The IaaS federation is a thin layer that brings the providers together with:
+The IaaS federation is a [thin layer](../../../internal) that brings the providers
+together with:
 
-- federated authentication;
-- resource discovery;
-- central VM image catalogue;
-- usage accounting; and
-- monitoring.
+- Federated authentication
+- Resource discovery
+- Central VM image catalogue
+- Usage accounting
+- Monitoring
 
 The IaaS capabilities (VM, block storage, network management) must be provided
 via community agreed APIs (OpenStack and/or OCCI are supported at the moment)
 that allow integration with EGI Check-in for authentication and authorisation of
 users. Those providers that limit the interaction to web dashboards and do not
 expose APIs to direct consumption for users cannot be considered part of the EGI
-IaaS Cloud Compute service.
+IaaS Cloud services.
 
 The information system provides a real-time view about the actual capabilities
-of federation participants. The EGI Configuration Database (GOCDB) contains the
-list of resource centres and their entry endpoints. Information about these
-endpoints is expressed in a standard format (GlueSchema 2.1) and pushed to
-consumers via the Argo Messaging System. The AppDB Information System collects
-this information in a central service for discovery.
+of federation participants. The EGI [Configuration Database](https://goc.egi.eu/)
+contains the list of resource centres and their entry endpoints. Information
+about these endpoints is expressed in a standard format (GlueSchema 2.1) and
+pushed to consumers via the Argo Messaging System. The AppDB Information System
+collects this information in a central service for discovery.
 
 Users can instantiate VMs on the providers from a set of Virtual Machine Images
 available on a central catalogue implemented in AppDB\'s Cloud Marketplace.
@@ -71,15 +72,16 @@ Usage of resources is gathered centrally using EGI Accounting repository and
 available for visualisation at
 [EGI Accounting portal](https://accounting.egi.eu).
 
-Those endpoints published in the EGI Configuration Database are monitored via
-[ARGO](https://argo.egi.eu/). The set of probes check the availability of the
-providers and their correct functionality.
+Those endpoints published in the [EGI Configuration Database](https://goc.egi.eu/)
+are monitored via [ARGO](https://argo.egi.eu/). The set of probes check the
+availability of the providers and their correct functionality.
 
 Users and Community platforms built on top of the EGI IaaS can interact with the
 cloud providers at three different layers:
 
-- Directly using the IaaS APIs to manage individual resources. This option is
-  recommended for pre-existing use cases with requirements on specific APIs.
+- Directly using the IaaS APIs or [CLIs](../cli) to manage individual
+  resources. This option is recommended for pre-existing use cases with
+  requirements on specific APIs.
 - Using IaaS Federated Access Tools that allow managing the complexity of
   dealing with different providers in a uniform way. These tools include:
   - IaaS provisioning systems that allow to define infrastructure as code and

--- a/content/en/users/getting-started/architecture/_index.md
+++ b/content/en/users/getting-started/architecture/_index.md
@@ -4,7 +4,7 @@ linkTitle: "Federation Architecture"
 type: docs
 weight: 10
 description: >
-  The architecture of the EGI FedCloud
+  The architecture of EGI FedCloud
 ---
 
 The EGI Federated Cloud (FedCloud) is a multi-national cloud system that

--- a/content/en/users/getting-started/cli/_index.md
+++ b/content/en/users/getting-started/cli/_index.md
@@ -3,7 +3,6 @@ title: "Command Line Interface"
 linkTitle: "Command Line"
 type: docs
 weight: 30
-draft: true
 description: >
   EGI FedCloud command line interface
 ---

--- a/content/en/users/getting-started/cli/_index.md
+++ b/content/en/users/getting-started/cli/_index.md
@@ -2,7 +2,7 @@
 title: "Command Line Interface"
 linkTitle: "Command Line"
 type: docs
-weight: 20
+weight: 30
 draft: true
 description: >
   EGI FedCloud command line interface

--- a/content/en/users/getting-started/cli/_index.md
+++ b/content/en/users/getting-started/cli/_index.md
@@ -7,4 +7,278 @@ description: >
   EGI FedCloud command line interface
 ---
 
-TBD
+## Command line tools
+
+The various [public EGI services](https://www.egi.eu/services/) can be managed
+and used/accessed with a wide variety of command line interface (CLI) tools.
+The documentation of each service contains a summary of the CLIs that can be
+used wih that service, together with recommendations on which one to use in
+what context.
+
+## The FedCloud client
+
+The [FedCloud client](https://fedcloudclient.fedcloud.eu/index.html) is a
+high-level Python package for a command-line client designed for interaction
+with the [OpenStack services](../openstack) in the EGI Federated Cloud
+(FedCloud).
+
+{{% alert title="Tip" color="info" %}} The FedCloud client is the recommended
+command line interface to use with most EGI services.
+{{% /alert %}}
+
+FedCloud client has the following modules (features):
+
+- [**Check-in**](https://fedcloudclient.fedcloud.eu/fedcloudclient.html#module-fedcloudclient.checkin)
+  allows checking validity of access tokens and listing
+  [Virtual Organisations](../../check-in/vos) (VOs) of a token
+- [**Endpoint**](https://fedcloudclient.fedcloud.eu/fedcloudclient.html#module-fedcloudclient.endpoint)
+  can search endpoints in the [Configuration Database](../../../internal/configuration-database) and extract site-specific information from
+  unscoped/scoped tokens
+- [**Sites**](https://fedcloudclient.fedcloud.eu/fedcloudclient.html#module-fedcloudclient.sites)
+  allows management of site configurations
+- [**OpenStack**](https://fedcloudclient.fedcloud.eu/fedcloudclient.html#module-fedcloudclient.openstack)
+  can perform commands on [OpenStack services](../openstack) deployed to sites
+- **EC3** allows deploying [elastic cloud compute clusters](../../cloud-compute/ec3)
+
+### Installation
+
+The FedCloud client can be installed with the `pip3` Python package manager
+(without root or aministrator privileges).
+
+{{< tabpanex >}}
+{{< tabx header="Linux / Mac" >}}
+
+To install the FedCloud client:
+
+```shell
+$ pip3 install fedcloudclient
+```
+
+This installs the latest version of the FedCloud client, together with
+its required packages (like _openstackclient_). It will also create
+executables **fedcloud** and **openstack**, adding them to the _bin_
+folder  corresponding to your current Python execution environment
+(_$VIRTUAL_ENV/bin_ for executing pip3 in a Python virtual environment,
+_~/.local/bin_ for executing pip3 as user (with --user option), and
+_/usr/local/bin_ when executing pip3 as root).
+
+{{< /tabx >}}
+{{< tabx header="Windows" >}}
+
+As there are non-pure Python packages needed for installation, the
+[Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+is a prerequisite, make sure it's installed with the following options
+selected:
+
+- C++ CMake tools for Windows
+- C++ ATL for latest v142 build tools (x86 & x64)
+- Testing tools core features - Build Tools
+- Windows 10 SDK (`<latest`>)
+
+In case you prefer to use non-Microsoft alternatives for building non-pure
+packages, please see [here](https://wiki.python.org/moin/WindowsCompilers).
+
+To install the FedCloud client:
+
+```shell
+> pip3 install fedcloudclient
+```
+
+This installs the latest version of the FedCloud client, together with
+its required packages (like _openstackclient_). It will also create
+executables **fedcloud** and **openstack**, adding them to the _bin_
+folder corresponding to your current Python execution environment.
+
+{{< /tabx >}}
+{{< /tabpanex >}}
+
+Check if the installation is correct by executing the client:
+
+```shell
+$ fedcloud --version
+```
+
+#### Installing EGI Core Trust Anchor certificates
+
+Some sites in the EGI infrastructure use certificates issued by
+Certificate Authorities (CAs) that are not included in the default OS
+distribution. If you receive error message "_SSL exception connecting
+to..._", install the EGI Core Trust Anchor Certificates by running
+the following commands:
+
+```shell
+$ wget https://raw.githubusercontent.com/tdviet/python-requests-bundle-certs/main/scripts/install_certs.sh
+$ bash install_certs.sh
+```
+
+{{% alert title="Note" color="info" %}} The above script does not work on all
+Linux distributions. Change _python_ to _python3_ in the script if needed,
+see the [README](https://github.com/tdviet/python-requests-bundle-certs#usage)
+for more details, or follow the
+[official instructions](https://github.com/tdviet/python-requests-bundle-certs/blob/main/docs/Install_certificates.md)
+for installing EGI Core Trust Anchor certificates in production environments.
+{{% /alert %}}
+
+### Using via Docker container
+
+The FedCloud client can also be used without installation, by running it in a
+Docker container. In this case, the EGI Core Trust Anchor certificates are
+preinstalled.
+
+To run the FedCloud client in a container, make sure
+[Docker is installed](https://docs.docker.com/engine/install/), then run the
+following commands:
+
+```shell
+$ sudo docker pull tdviet/fedcloudclient
+$ sudo docker run -it  tdviet/fedcloudclient bash
+```
+
+Once you have a shell running in the container with the FedCloud client, usage
+is the same as from [the command line](#using-from-the-command-line).
+
+### Using from the command line
+
+The FedCloud client has these subcommands:
+
+- **fedcloud token** for checking access tokens
+  (see [subcommands](https://fedcloudclient.fedcloud.eu/usage.html#fedcloud-token-commands))
+- **fedcloud endpoint** for querying the Configuration Database
+  (see [subcommands](https://fedcloudclient.fedcloud.eu/usage.html#fedcloud-endpoint-commands))
+- **fedcloud site** for manipulating site configurations
+  (see [subcommands](https://fedcloudclient.fedcloud.eu/usage.html#fedcloud-site-commands))
+- **fedcloud openstack** or **fedcloud openstack-int** for performing
+  OpenStack commands on sites
+  (see [subcommands](https://fedcloudclient.fedcloud.eu/usage.html#fedcloud-openstack-commands))
+- **fedcloud ec3** for provisioning elastic cloud compute clusters
+  (see [subcommands](https://fedcloudclient.fedcloud.eu/usage.html#fedcloud-ec3-commands))
+
+{{% alert title="Note" color="info" %}} See also the
+[complete documentation](https://fedcloudclient.fedcloud.eu/index.html)
+or read and contribute to the
+[source code](https://github.com/EGI-Federation/fedcloudclient).
+{{% /alert %}}
+
+Performing any OpenStack command on any site requires only three options: the
+site, the VO and the command. For example, to list virtual machine (VM) images
+available to members of VO _fedcloud.egi.eu_ on the site _CYFRONET-CLOUD_, run
+the following command:
+
+```shell
+$ fedcloud openstack image list --vo fedcloud.egi.eu --site CYFRONET-CLOUD
+```
+
+#### Authentication
+
+Many of the FedCloud client commands need access tokens for authentication.
+Users can choose whether to provide access tokens directly (via option
+`--oidc-access-token`), or generate them on the fly with **oidc-agent**
+(via option `--oidc-agent-account`) or from refresh tokens (via option
+`--oidc-refresh-token`, which must be provided together
+with a option `--oidc-client-id` and option `--oidc-client-secret`).
+
+{{% alert title="Tip" color="info" %}} Users of EGI Check-in can get a Check-in
+client ID, client secret, and refresh token, as well as all the information
+needed to obtain access tokens for their FedCloud client, by visiting
+[Check-in FedCloud client](https://aai.egi.eu/fedcloud/).
+{{% /alert %}}
+
+{{% alert title="Tip" color="info" %}} To provide access tokens automatically
+via **oidc-agent**, follow [these instructions](https://indigo-dc.gitbook.io/oidc-agent/user/oidc-gen/provider/egi/)
+to register a client, then pass the client name (account name used during
+client registration) to the FedCloud client via option `--oidc-agent-account`.
+{{% /alert %}}
+
+{{% alert title="Important" color="warning" %}} Refresh tokens have long
+lifetime (one year in EGI Check-in), so they must be properly protected.
+Exposing refresh tokens via environment variables or command-line options is
+considered insecure and will be disabled in the near future in favor of using
+**oidc-agent**.
+{{% /alert %}}
+
+If multiple methods of getting access tokens are given at the same time, the
+FedCloud client will try to get an access tokens from the **oidc-agent** first,
+then obtain one using the refresh token.
+
+The default authentication protocol is `openid`. Users can change the default
+protocol via the option `--openstack-auth-protocol`. However, sites may have
+the protocol fixed in the site configuration (e.g. `oidc` for the site
+INFN-CLOUD-BARI).
+
+The default OIDC identity provider is EGI Check-in (https://aai.egi.eu/oidc).
+Users can set another OIDC identity provider via option `--oidc-url`. 
+
+{{% alert title="Note" color="info" %}} Remember to also set the identity
+provider's name accordingly for OpenStack commands, by using the option `--openstack-auth-provider`.
+{{% /alert %}}
+
+#### Environment variables
+
+Most of the FedCloud client options can be set via environment variables:
+
+{{% alert title="Tip" color="info" %}} To save a lot of time, set the frequently
+used options like site, VO, access tokens, etc. using environment variables.
+{{% /alert %}}
+
+
+
+#### Getting help
+
+The FedCloud client can display help for the commands and subcommands it
+supports. Try running the following command to see the commands supported
+by the FedCloud client:
+
+```shell
+$ fedcloud --help
+Usage: fedcloud [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --version  Show the version and exit.
+  --help     Show this message and exit.
+
+Commands:
+  ec3            EC3 related comands
+  endpoint       endpoint command group for interaction with GOCDB and...
+  openstack      Executing OpenStack commands on site and VO
+  openstack-int  Interactive OpenStack client on site and VO
+  site           Site command group for manipulation with site...
+  token          Token command group for manipulation with tokens
+```
+
+Similarly, you can see help for e.g. the `openstack` subcommand by running the
+command below:
+
+```shell
+$ fedcloud openstack --help
+Usage: fedcloud openstack [OPTIONS] OPENSTACK_COMMAND...
+
+  Executing OpenStack commands on site and VO
+
+Options:
+  --oidc-client-id TEXT           OIDC client id
+  --oidc-client-secret TEXT       OIDC client secret
+  --oidc-refresh-token TEXT       OIDC refresh token
+  --oidc-access-token TEXT        OIDC access token
+  --oidc-url TEXT                 OIDC URL  [default: https://aai.egi.eu/oidc]
+  --oidc-agent-account TEXT       short account name in oidc-agent
+  --openstack-auth-protocol TEXT  Check-in protocol  [default: openid]
+  --openstack-auth-type TEXT      Check-in authentication type  [default:
+                                  v3oidcaccesstoken]
+  --openstack-auth-provider TEXT  Check-in identity provider  [default:
+                                  egi.eu]
+  --site TEXT                     Name of the site  [required]
+  --vo TEXT                       Name of the VO  [required]
+  -i, --ignore-missing-vo         Ignore sites that do not support the VO
+  -j, --json-output               Print output as a big JSON object
+  --help                          Show this message and exit.
+```
+
+{{% alert title="Note" color="info" %}} Most commands support multiple levels
+of subcommands, you can get help for all of them using the same principle as
+above.
+{{% /alert %}}
+
+### Using from Python
+
+### Using in scripts
+

--- a/content/en/users/getting-started/cli/_index.md
+++ b/content/en/users/getting-started/cli/_index.md
@@ -1,8 +1,8 @@
 ---
 title: "Command Line Interface"
-linkTitle: "Command Line Interface"
+linkTitle: "Command Line"
 type: docs
-weight: 10
+weight: 20
 draft: true
 description: >
   EGI FedCloud command line interface

--- a/content/en/users/getting-started/openstack/_index.md
+++ b/content/en/users/getting-started/openstack/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Using OpenStack Providers"
+linkTitle: "OpenStack Providers"
+type: docs
+weight: 10
+draft: true
+description: >
+  How to interact with OpenStack providers in the EGI Cloud
+---
+
+[OpenStack](https://openstack.org) providers of the EGI Cloud offer services
+and features via OpenStack APIs and the OpenStack [command line interface](../cli)
+(CLI), integrated with [EGI Check-in](../../check-in) accounts.
+
+The extensive [OpenStack user documentation](https://docs.openstack.org/user/)
+includes details on every OpenStack project, but most providers offer:
+
+- [Keystone](https://docs.openstack.org/keystone/latest/), for identity
+- [Nova](https://docs.openstack.org/nova/latest/), for VM management
+- [Glance](https://docs.openstack.org/glance/latest/), for VM image
+  management
+- [Cinder](https://docs.openstack.org/cinder/latest/), for block storage
+- [Neutron](https://docs.openstack.org/neutron/latest/), for network
+  management
+- [Horizon](https://docs.openstack.org/horizon/latest/), as a web
+  dashboard
+
+The web-dashboard of the individual providers can be accessed using your EGI
+Check-in credentials directly: select _OpenID Connect_ or _EGI Check-in_ in the
+**Authenticate using** drop-down menu of the login screen.

--- a/content/en/users/getting-started/openstack/_index.md
+++ b/content/en/users/getting-started/openstack/_index.md
@@ -2,7 +2,7 @@
 title: "Using OpenStack Providers"
 linkTitle: "OpenStack Providers"
 type: docs
-weight: 10
+weight: 20
 draft: true
 description: >
   How to interact with OpenStack providers in the EGI Cloud

--- a/content/en/users/getting-started/openstack/_index.md
+++ b/content/en/users/getting-started/openstack/_index.md
@@ -3,7 +3,6 @@ title: "Using OpenStack Providers"
 linkTitle: "OpenStack Providers"
 type: docs
 weight: 20
-draft: true
 description: >
   How to interact with OpenStack providers in the EGI FedCloud
 ---

--- a/content/en/users/getting-started/openstack/_index.md
+++ b/content/en/users/getting-started/openstack/_index.md
@@ -20,6 +20,7 @@ includes details on every OpenStack project, but most providers offer:
 - [Glance](https://docs.openstack.org/glance/latest/), for VM image
   management
 - [Cinder](https://docs.openstack.org/cinder/latest/), for block storage
+- [Swift](https://docs.openstack.org/swift/latest/), for object storage
 - [Neutron](https://docs.openstack.org/neutron/latest/), for network
   management
 - [Horizon](https://docs.openstack.org/horizon/latest/), as a web

--- a/content/en/users/getting-started/openstack/_index.md
+++ b/content/en/users/getting-started/openstack/_index.md
@@ -5,12 +5,13 @@ type: docs
 weight: 20
 draft: true
 description: >
-  How to interact with OpenStack providers in the EGI Cloud
+  How to interact with OpenStack providers in the EGI FedCloud
 ---
 
-[OpenStack](https://openstack.org) providers of the EGI Cloud offer services
-and features via OpenStack APIs and the OpenStack [command line interface](../cli)
-(CLI), integrated with [EGI Check-in](../../check-in) accounts.
+[OpenStack](https://openstack.org) providers in the EGI Federated Cloud
+(FedCloud) offer services and features via OpenStack APIs, and the
+[command line interface](../cli) (CLI), both integrated with
+[EGI Check-in](../../check-in) accounts.
 
 The extensive [OpenStack user documentation](https://docs.openstack.org/user/)
 includes details on every OpenStack project, but most providers offer:
@@ -26,6 +27,7 @@ includes details on every OpenStack project, but most providers offer:
 - [Horizon](https://docs.openstack.org/horizon/latest/), as a web
   dashboard
 
-The web-dashboard of the individual providers can be accessed using your EGI
-Check-in credentials directly: select _OpenID Connect_ or _EGI Check-in_ in the
-**Authenticate using** drop-down menu of the login screen.
+The web-dashboard of the individual providers can be used to manage and use
+services. It can be accessed using EGI Check-in credentials directly:
+select _OpenID Connect_ or _EGI Check-in_ in the **Authenticate using**
+drop-down menu of the login screen.

--- a/content/en/users/high-throughput-compute/_index.md
+++ b/content/en/users/high-throughput-compute/_index.md
@@ -106,8 +106,3 @@ VOs are fully managed by research communities, allowing them to manage their
 users and grant access to their services and resources. This means users can
 either own their resources and use EGI services to federate them, or can use
 the resources available in the EGI infrastructure.
-
-Users may gain opportunistic usage to unused resources. These are resources
-that are not dedicated to the users’ organization, but are accessible when the
-research center(s) have some spare resources. This enables the most efficient
-use of resources.

--- a/content/en/users/high-throughput-compute/_index.md
+++ b/content/en/users/high-throughput-compute/_index.md
@@ -4,22 +4,24 @@ dlinkTitle: "High Throughput Compute"
 type: docs
 weight: 60
 description: >
-  EGI High Throughput Compute (HTC) service
+  EGI High Throughput Compute service
 ---
 
 ## What is it?
 
-High Throughput Compute is a computing paradigm that focuses on the **efficient
-execution of a large number of loosely-coupled tasks** (e.g. data analysis jobs).
+High Throughput Compute (HTC) is a computing paradigm that focuses on the
+**efficient execution of a large number of loosely-coupled tasks** (e.g. data
+analysis jobs).
 HTC systems execute independent tasks that can be individually scheduled on many
 different computing resources, across multiple administrative boundaries.
 Users submit these tasks to the infrastructure as jobs. After a job have been
 scheduled and executed, the output can be collected from the service(s) that
 executed the job.
 
-The EGI High Throughput Compute service is provided by a distributed network of
-computing centres. Access is through a standard interface, and conditioned by
-membership in a [Virtual Organisation](../check-in/vos) (VO).
+{{% alert title="Note" color="info" %}} For more details check out the
+[introduction](../getting-started) to the EGI Federated Cloud (FedCloud) that
+provides the HTC resources, and the [access model](../getting-started#accessing-resources) to those resources.
+{{% /alert %}}
 
 ## Target users
 
@@ -94,15 +96,3 @@ The key components of the EGI High Throughput Compute architecture are:
   infrastructure are
   [HTCondor-CE](https://htcondor-ce.readthedocs.io/en/latest/) and
   [ARC-CE](http://www.nordugrid.org/arc/ce/).
-
-### Access model
-
-Access to EGI High Throughput Compute resources is based on
-[Virtual Organisations](../check-in/vos), which
-rely on [X.509 proxy certificates with VOMS extensions](../check-in/vos/voms).
-Users have to enroll into one VO before using the service.
-
-VOs are fully managed by research communities, allowing them to manage their
-users and grant access to their services and resources. This means users can
-either own their resources and use EGI services to federate them, or can use
-the resources available in the EGI infrastructure.

--- a/content/en/users/online-storage/block-storage/_index.md
+++ b/content/en/users/online-storage/block-storage/_index.md
@@ -317,7 +317,7 @@ unless the volume driver supports
 
 <!-- markdownlint-disable line-length -->
 ```shell
-$ fedcloud openstack volume set --size 20 volume my-volume
+$ fedcloud openstack volume set --size 20 my-volume
 Site: IN2P3-IRES, VO: vo.access.egi.eu, command: volume set --size 20 my-volume
 ```
 <!-- markdownlint-enable line-length -->

--- a/content/en/users/online-storage/block-storage/_index.md
+++ b/content/en/users/online-storage/block-storage/_index.md
@@ -317,7 +317,7 @@ unless the volume driver supports
 
 <!-- markdownlint-disable line-length -->
 ```shell
-$ fedcloud openstack volume set --size 20 volume my-server my-volume
+$ fedcloud openstack volume set --size 20 volume my-volume
 Site: IN2P3-IRES, VO: vo.access.egi.eu, command: volume set --size 20 my-volume
 ```
 <!-- markdownlint-enable line-length -->

--- a/content/en/users/tutorials/_index.md
+++ b/content/en/users/tutorials/_index.md
@@ -5,9 +5,10 @@ type: docs
 weight: 5
 draft: true
 description: >
-  Turorials for common use-cases in EGI Cloud
+  Turorials for common use-cases in EGI FedCloud
 ---
 
-The following tutorials show you how to perform common tasks in the EGI Cloud.
+The following tutorials show you how to perform common tasks in the
+EGI Federated Cloud (FedCloud).
 These describe how to set up the EGI services needed for each use-case,
 and how to connect or operate them togheter.


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the [Contributing guide](https://docs.egi.eu/about/contributing/)
for style requirements and advice.
-->

This is an introduction to using the public EGI services. It contains a presentation of the FedCloud, how it is built from service providers, how to access/request resources and how those get allocated, how to access OpenStack deployments. The recommended CLI is also described in detail here. This should allow all other sections to reference pages from here, instead of rewording these over and over again, in the documentation of basically all services.

Redone the landing page for user documentation.
Federation architecture moved here from under Cloud Compute section.

<!-- Describe in plain English what this PR does -->

---
TODO: Redo the page Cloud Compute/OpenStack to only keep the parts relevant to creating/managing VMs.
TODO: Revisit documentation for all services, including tutorials, and link to pages in this section.
