### PR TITLE
Add workflow trying to deploy to alternate repo from a PR

### DIFF
--- a/.github/workflows/preview_pr.yml
+++ b/.github/workflows/preview_pr.yml
@@ -4,8 +4,6 @@ name: Preview pull requests
 # https://github.com/peaceiris/actions-hugo
 # Deploy to GitHub pages
 # https://github.com/peaceiris/actions-gh-pages
-#
-# FIXME: deploy to a path corresponding to the current PR
 
 on:
   pull_request:
@@ -48,7 +46,8 @@ jobs:
         run: npm ci
 
       - name: Build and minify using Hugo
-        run: hugo --minify
+        # Build in a directory specific to the PR number
+        run: hugo --minify --destination public/${{ github.event.number }}
 
       - name: Generate token for pushing content
         uses: tibdex/github-app-token@v1

--- a/.github/workflows/preview_pr.yml
+++ b/.github/workflows/preview_pr.yml
@@ -1,0 +1,72 @@
+---
+name: Preview pull requests
+# Setup and build files with hugo
+# https://github.com/peaceiris/actions-hugo
+# Deploy to GitHub pages
+# https://github.com/peaceiris/actions-gh-pages
+#
+# FIXME: deploy to a path corresponding to the current PR
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  deploy:
+    if: ${{ github.event.label.name == 'preview' }}
+    name: Build with Hugo
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Fetch the Docsy theme
+          submodules: recursive
+          # Fetch all history for .GitInfo and .Lastmod
+          fetch-depth: 0
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: "0.66.0"
+          extended: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          # NodeJS 12 is maintained until 2022-04-30
+          node-version: "12.x"
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install npm project with a clean slate
+        run: npm ci
+
+      - name: Build and minify using Hugo
+        run: hugo --minify
+
+      - name: Generate token for pushing content
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Deploy
+        # Deploy should not run on forks
+        if: ${{ github.repository == 'EGI-Federation/documentation' }}
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          # Use a personal token configured as a repository-specific secret
+          personal_token: ${{ steps.generate-token.outputs.token }}
+          # Push to the preview repository
+          # Accessible at http://docs.egi.eu/documentation-preview/
+          external_repository: EGI-Federation/documentation-preview
+          # XXX use a different domain
+          # cname: docs.egi.eu
+          publish_branch: main


### PR DESCRIPTION
Add workflow trying to deploy to alternate repo from a PR.
* For security reasons only PR having the label `preview` added to them will be build and deploy for preview. See https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels, only people having at least triage access can apply/dismiss labels
* The deploy is done to an alternate repository: https://github.com/EGI-Federation/documentation-preview/
* The rendering should be available at http://docs.egi.eu/documentation-preview/{PR}
Fix #173.