### PR TITLE
markdownlint: disable line-length and command-show-output as previously discussed.

### DIFF
--- a/.github/linters/.markdownlint.json
+++ b/.github/linters/.markdownlint.json
@@ -1,4 +1,6 @@
 {
+  "MD013": false,
+  "MD014": false,
   "MD024": false,
   "MD026": {
     "punctuation": ".,:;!"


### PR DESCRIPTION
markdownlint: disable line-length and command-show-output as previously discussed.

* [line-length](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md013---line-length)
* [command-show-output](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md014)

Discussed in #271 and #272.