### PR TITLE
Try to find syntax for configuring MD013 exceptions

### DIFF
--- a/.github/linters/.markdownlint.json
+++ b/.github/linters/.markdownlint.json
@@ -1,5 +1,9 @@
 {
-  "MD013": false,
+  "MD013": {
+    "line_length": 120,
+    "code_blocks": false,
+    "tables": false
+  },
   "MD014": false,
   "MD024": false,
   "MD026": {


### PR DESCRIPTION
Try to find syntax for configuring MD013 exceptions, see https://github.com/EGI-Federation/documentation/pull/317/checks?check_run_id=3536232892#step:4:103 from #317.

This PR should set a max line length of 120 to be more comfortable, with line length checks disabled for code excerpts and tables that are the legit cases for longer lines.

See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013