### PR TITLE
Remove the RSA key markers to lazily address errors reports by gitleaks

### DIFF
--- a/content/en/users/tutorials/data-transfer-grid-storage/_index.md
+++ b/content/en/users/tutorials/data-transfer-grid-storage/_index.md
@@ -186,11 +186,7 @@ following command:
 $ openssl pkcs12 -in yourCert.p12 -nocerts -nodes | openssl rsa
 Enter Import Password:
 writing RSA key
------BEGIN RSA PRIVATE KEY-----
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-...
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
------END RSA PRIVATE KEY-----
+(...)
 ```
 
 Which extract the private key in RSA format and you can paste it in the windows


### PR DESCRIPTION
Remove the RSA key markers to lazily address errors reports by gitleaks, see https://github.com/EGI-Federation/documentation/pull/333/checks?check_run_id=3755392770#step:4:1064

https://github.com/zricethezav/gitleaks

It's desirable to keep gitleaks running and showing the PRIVATE KEY tags doesn't seem to be that required/useful.