### PR TITLE
Add GGUS to exceptions

### DIFF
--- a/.github/linters/mlc_config.json
+++ b/.github/linters/mlc_config.json
@@ -35,6 +35,9 @@
     },
     {
       "pattern": "^https://www.eugridpma.org/your-identity/"
+    },
+    {
+      "pattern": "^https://ggus.eu/*"
     }
   ]
 }


### PR DESCRIPTION
GGUS is behind a certificate, and therefore cannot be accessed by the link checker

This is required for Rucio documentation to not have link exceptions added