### PR TITLE
Move initial documentation for Collaboration Tools

### DIFF
--- a/content/en/internal/collaboration-tools/_index.md
+++ b/content/en/internal/collaboration-tools/_index.md
@@ -39,10 +39,10 @@ egi.eu domain.
 Requests needs to be discussed with the
 [EGI Operations team](mailto:operations@egi.eu).
 
-### EGI.eu website
+### EGI.eu site
 
 Information about the EGI Federation activities is published on the
-[public website](https://www.egi.eu).
+[public site](https://www.egi.eu).
 
 ### Wiki
 

--- a/content/en/internal/collaboration-tools/_index.md
+++ b/content/en/internal/collaboration-tools/_index.md
@@ -76,28 +76,11 @@ be crated on request as documented below.
 Membership in mailing lists is usually determined by membership in EGI SSO
 groups. Only group owners can manage the group membership.
 
-List administrators can find some helpful information on the
-[Mailing Lists Administration page](https://wiki.egi.eu/wiki/Mailing_list_administration).
 Note that canonical addresses are `list-name@mailman.egi.eu`, not
 `list-name@egi.eu`.
 
-#### Requesting the creation of a new mailing list
-
-> By default all mailing lists are managed using groups in EGI SSO. Only for
-> very specific they may be managed directly in mailman.
-
-Open a ticket to Collaboration Tools SU in [EGI Helpdesk](../helpdesk),
-providing:
-
-- List name
-- List Description
-- List administrator contact
-
-After validation of those information the list will be created.
-
-Name and description of the mailing list will be validated, you may be
-recommended to change name or description to follow already existing best
-practices for naming, or to improve description.
+See the [dedicated page on mailing list](./mailing-lists) for more information
+like how to request the creation of a new mailing list.
 
 ### Document server
 

--- a/content/en/internal/collaboration-tools/_index.md
+++ b/content/en/internal/collaboration-tools/_index.md
@@ -1,0 +1,125 @@
+---
+title: "Collaboration Tools"
+type: docs
+weight: 20
+description: >
+  Fostering Collaboration across the EGI Federation
+---
+
+## What is it?
+
+The EGI Collaboration Tools are a set of online services maintained by the EGI
+Foundation and meant to support collaboration across the EGI Federation,
+supporting its daily activities (sharing information and documents, organising
+meetings, communicating in task or project specific groups...).
+
+{{% alert title="Note" color="info" %}} Component-specific documentation is
+maintained by the upstream software providers. {{% /alert %}}
+
+## What are the components?
+
+### EGI Single Sign On (EGI SSO)
+
+Central authentication and authorisation service allowing to use a single
+username and password to access various Collaboration Tools.
+
+Group owners can manage group members, and send invitations to new users. Groups
+are used in Collaboration Tools services for authorisation.
+
+> EGI SSO is now being deprecated in favour of
+> [EGI Check-in](../../users/check-in), providing a federation authentication
+> and authorisation service.
+
+### EGI.eu domain
+
+Domain entries can be created for the service as long as they are relevant for
+the EGI infrastructure. All EGI central services are usually available under the
+egi.eu domain.
+
+Requests needs to be discussed with the
+[EGI Operations team](mailto:operations@egi.eu).
+
+### EGI.eu website
+
+Information about the EGI Federation activities is published on the
+[public web site](https://www.egi.eu).
+
+### Wiki
+
+A [Confluence-based](https://www.atlassian.com/software/confluence/guides)
+"Wiki" space is available, allowing the EGI members to work collaboratively on
+documenting many aspects like Service Management,
+[Polices and Procedures](https://confluence.egi.eu/display/EGIPP) or activities
+from [Boards and Groups](https://confluence.egi.eu/display/EGIBG).
+
+Separate instances for EGI and EOSC are operated by EGI Foundation.
+
+### Issues management
+
+#### Jira
+
+EGI internal request tracking system, meant to support the Service Management
+System and projects.
+
+EGI Foundation is operating dedicated instances for EGI and EOSC.
+
+#### Request Tracking (RT)
+
+EGI internal request tracking system, being replaced for many activities by
+Jira.
+
+### Mailing lists
+
+Many mailing lists exists to cover specific areas of collaboration. New ones can
+be crated on request as documented below.
+
+Membership in mailing lists is usually determined by membership in EGI SSO
+groups. Only group owners can manage the group membership.
+
+List administrators can find some helpful information on the
+[Mailing Lists Administration page](https://wiki.egi.eu/wiki/Mailing_list_administration).
+Note that canonical addresses are `list-name@mailman.egi.eu`, not
+`list-name@egi.eu`.
+
+#### Requesting the creation of a new mailing list
+
+> By default all mailing lists are managed using groups in EGI SSO. Only for
+> very specific they may be managed directly in mailman.
+
+Open a ticket to Collaboration Tools SU in [EGI Helpdesk](../helpdesk),
+providing:
+
+- List name
+- List Description
+- List administrator contact
+
+After validation of those information the list will be created.
+
+Name and description of the mailing list will be validated, you may be
+recommended to change name or description to follow already existing best
+practices for naming, or to improve description.
+
+### Document server
+
+[EGI Documentation database](https://documents.egi.eu), hosting many published
+document relevant to the EGI Federation.
+
+Documents have metadata describing them and can be versioned. EGI SSO groups are
+used for restricting access to documents.
+
+### Agenda management via Indico
+
+Event planner, used for various conferences and meetings, powered by the
+[Indico](https://getindico.io/) product.
+
+All users with an SSO account can use it.
+
+Indico also has its own local accounts, which can be used by people who do not
+want an EGI SSO account, but want to register to some meeting in Indico.
+
+## Contact
+
+EGI Collaboration Tools support can be contacted via:
+
+- [EGI Helpdesk](../helpdesk) Support Unit "Collaboration Tools"
+- [EGI IT Suport](it-support@egi.eu)

--- a/content/en/internal/collaboration-tools/_index.md
+++ b/content/en/internal/collaboration-tools/_index.md
@@ -105,4 +105,4 @@ want an EGI SSO account, but want to register to some meeting in Indico.
 EGI Collaboration Tools support can be contacted via:
 
 - [EGI Helpdesk](../helpdesk) Support Unit "Collaboration Tools"
-- [EGI IT Suport](it-support@egi.eu)
+- [EGI IT Support](mailto:it-support@egi.eu)

--- a/content/en/internal/collaboration-tools/_index.md
+++ b/content/en/internal/collaboration-tools/_index.md
@@ -42,7 +42,7 @@ Requests needs to be discussed with the
 ### EGI.eu website
 
 Information about the EGI Federation activities is published on the
-[public web site](https://www.egi.eu).
+[public website](https://www.egi.eu).
 
 ### Wiki
 

--- a/content/en/internal/collaboration-tools/mailing-lists/_index.md
+++ b/content/en/internal/collaboration-tools/mailing-lists/_index.md
@@ -1,0 +1,82 @@
+---
+title: "Mailing lists"
+type: docs
+weight: 20
+description: >
+  Mailing lists usage
+---
+
+Mailing lists are managed by software called Mailman.
+
+The software provides a web interface and a
+[public list of mailing lists](https://mailman.egi.eu/mailman/listinfo) is
+available.
+
+## Requesting the creation of a new mailing list
+
+> By default all mailing lists are managed using groups in EGI SSO. Only for
+> very specific they may be managed directly in mailman.
+
+Open a ticket to Collaboration Tools SU in [EGI Helpdesk](../helpdesk),
+providing:
+
+- List name
+- List Description
+- List administrator contact
+
+After validation of those information the list will be created.
+
+Name and description of the mailing list will be validated, you may be
+recommended to change name or description to follow already existing best
+practices for naming, or to improve description.
+
+## List administrators
+
+EGI mailing lists are usually managed by EGI SSO, with some exceptions for lists
+that include members without SSO accounts.
+
+List administrators of every SSO-managed list are set to the owners of the
+corresponding EGI SSO group when a new list is created.
+
+{{% alert title="Note" color="info" %}} For SSO managed-lists: a change to the
+list of list administrators through the Mailman interface will not be permanent.
+{{% /alert %}}
+
+Only the EGI IT support can change who are the owners of an SSO group, please
+[contact us](mailto:it-support@egi.eu) if you want to add a new list
+administrator.
+
+Each list can be administered over the web interface by following its link from
+the page Admin links. You can use your EGI SSO password to access the
+administration pages of the lists for which you are the administrator.
+
+## List members
+
+Members of lists are synchronized with members of same named groups in the EGI
+SSO system.
+
+{{% alert title="Note" color="info" %}} For SSO managed-lists: Changes made to
+list membership through the Mailman interface will not be permanent.
+{{% /alert %}}
+
+Managing list members must be done by managing members of corresponding groups
+in EGI SSO. Log into your EGI SSO account, and you will see a list of groups of
+which you are the owner. Click on the "»manage" link, it will display a page
+where you can
+
+- remove members from the group
+- add existing users as members of thew group
+- invite new users to the group
+
+If you manage more then one list, and you need to add many new users to several
+lists at once, it may be helpful to follow the link titled "»Create new users in
+groups". It directs to a page where you can enter many addresses at once, and
+specify the groups to which they should be added. Existing users will be added
+immediately, non-existing users will be invited to create an account and they
+will be assigned to the groups when they create the account.
+
+## Documentation
+
+- [Mailman documentation](http://www.gnu.org/software/mailman/docs.html)
+- [Mailman Frequently Asked Questions](https://wiki.list.org/DOC/Frequently%20Asked%20Questions)
+- [List administrator tasks](https://wiki.list.org/DOC/3%20List%20administrator%20tasks)

--- a/content/en/internal/collaboration-tools/mailing-lists/_index.md
+++ b/content/en/internal/collaboration-tools/mailing-lists/_index.md
@@ -17,7 +17,7 @@ available.
 > By default all mailing lists are managed using groups in EGI SSO. Only for
 > very specific they may be managed directly in mailman.
 
-Open a ticket to Collaboration Tools SU in [EGI Helpdesk](../helpdesk),
+Open a ticket to Collaboration Tools SU in [EGI Helpdesk](../../helpdesk),
 providing:
 
 - List name

--- a/content/en/internal/collaboration-tools/service-information/_index.md
+++ b/content/en/internal/collaboration-tools/service-information/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Service information"
+description: "Technical details of the Collaboration Tools"
+weight: 10
+type: "docs"
+---
+
+## Identity card
+
+<!-- markdownlint-disable no-inline-html no-bare-urls -->
+
+| Property                                | Value                                                                                         |
+| --------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Name                                    | Collaboration Tools                                                                           |
+| Description                             | Supporting Collaboration across the EGI Federation                                            |
+| URL                                     | N/A                                                                                           |
+| Support Email                           | it-support@egi.eu                                                                             |
+| [Helpdesk](../../helpdesk) Support Unit | **EGI Services and Service Components** <br/> I\_\_ Collaboration Tools                       |
+| Configuration Database entry            | https://goc.egi.eu/portal/index.php?Page_Type=Site&id=983                                     |
+| Supplier                                | [EGI Foundation](https://www.egi.eu/) and [CESNET](https://www.cesnet.cz/?lang=en)            |
+| Roadmap                                 | N/A                                                                                           |
+| Release notes                           | N/A                                                                                           |
+| Source code                             | N/A                                                                                           |
+| Issue tracker for developers            | N/A                                                                                           |
+| License                                 | Every component is having its own licence                                                     |
+| Privacy Policy                          | [Privacy policy](https://www.egi.eu/privacy-policy/), component usually have their own policy |
+
+<!-- markdownlint-enable no-inline-html no-bare-urls -->

--- a/content/en/internal/collaboration-tools/service-information/_index.md
+++ b/content/en/internal/collaboration-tools/service-information/_index.md
@@ -23,6 +23,6 @@ type: "docs"
 | Source code                             | N/A                                                                                           |
 | Issue tracker for developers            | N/A                                                                                           |
 | License                                 | Every component is having its own licence                                                     |
-| Privacy Policy                          | [Privacy policy](https://www.egi.eu/privacy-policy/), component usually have their own policy |
+| Privacy Policy                          | Parent [policy](https://www.egi.eu/privacy-policy/), components usually have their own policy |
 
 <!-- markdownlint-enable no-inline-html no-bare-urls -->


### PR DESCRIPTION
* Include a page about Collaboration Tools moved from https://wiki.egi.eu/wiki/EGI_Collaboration_tools
* Include a page about mailman moved from https://wiki.egi.eu/wiki/Mailing_list_administration