### PR TITLE
COU admin role vs membership

### DIFF
--- a/content/en/users/aai/check-in/vos/_index.md
+++ b/content/en/users/aai/check-in/vos/_index.md
@@ -283,7 +283,7 @@ A CO Person is added to a COU Admin Group if the following requirements are met:
 under the [Operations Portal](https://operations-portal.egi.eu/vo/a/list)
 
 1. A request is made to the Check-in Support Unit via a
-[EGI Helpdesk ticket](https://ggus.eu/).
+[EGI Helpdesk ticket](../../../../internal/helpdesk/user-guide/).
 
 ### Expiration Policy
 

--- a/content/en/users/aai/check-in/vos/_index.md
+++ b/content/en/users/aai/check-in/vos/_index.md
@@ -283,7 +283,7 @@ A CO Person is added to a COU Admin Group if the following requirements are met:
 under the [Operations Portal](https://operations-portal.egi.eu/vo/a/list)
 
 1. A request is made to the Check-in Support Unit via a
-[GGUS ticket](https://ggus.eu/).
+[EGI Helpdesk ticket](https://ggus.eu/).
 
 ### Expiration Policy
 

--- a/content/en/users/aai/check-in/vos/_index.md
+++ b/content/en/users/aai/check-in/vos/_index.md
@@ -274,16 +274,16 @@ groups is
 For example `CO:COU:vo.example.org:admins`
 
 - A CO Person can be a member, an owner, both, or neither. Specifically:
-  - A COU admins group member can manage COU members:
+  - COU Admin Group members can manage COU members
   - Approve or decline membership petitions
 
-COU Admin role is granted to a CO Person if the following requirements are met:
+A CO Person is added to a COU Admin Group if the following requirements are met:
 
 1. CO Person is declared as VO administrator in the VO's ID Card,
-under the Operations Portal
+under the [Operations Portal](https://operations-portal.egi.eu/vo/a/list)
 
-1. Open and assign to the Check-in support team a GGUS ticket with the role
-provisioning request.
+1. A request is made to the Check-in Support Unit via a
+[GGUS ticket](https://ggus.eu/).
 
 ### Expiration Policy
 


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the [Contributing guide](https://docs.egi.eu/about/contributing/)
for style requirements and advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

Please correct me if I am wrong but the following sentence is confusing in https://docs.egi.eu/users/aai/check-in/vos/#managing-cou-admin-members:

> COU Admin role is granted to a CO Person

Example of roles are `vm_operator` or `member`, so rather than using `COU Admin` role I think it is better to say `COU Admin Group` membership.

What do you think?

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
