### PR TITLE
Document certificate provisioning

### DIFF
--- a/content/en/internal/collaboration-tools/_index.md
+++ b/content/en/internal/collaboration-tools/_index.md
@@ -27,14 +27,14 @@ Group owners can manage group members, and send invitations to new users. Groups
 are used in Collaboration Tools services for authorisation.
 
 > EGI SSO is now being deprecated in favour of
-> [EGI Check-in](../../users/check-in), providing a federation authentication
-> and authorisation service.
+> [EGI Check-in](../../users/aai/check-in), providing a federation
+> authentication and authorisation service.
 
 ### EGI.eu domain
 
 Domain entries can be created for the service as long as they are relevant for
 the EGI infrastructure. All EGI central services are usually available under the
-egi.eu domain.
+`egi.eu` domain.
 
 Requests needs to be discussed with the
 [EGI Operations team](mailto:operations@egi.eu).

--- a/content/en/internal/collaboration-tools/_index.md
+++ b/content/en/internal/collaboration-tools/_index.md
@@ -39,6 +39,18 @@ egi.eu domain.
 Requests needs to be discussed with the
 [EGI Operations team](mailto:operations@egi.eu).
 
+#### Certificate for EGI.eu domain
+
+EGI Foundation is having access to a
+[GÉANT Trusted Certificate Service](https://wiki.geant.org/display/TCSNT/)
+subscription.
+
+This can be used to issue IGTF-trust (AKA eScience certificates) and
+public-trust certificates, for the domains managed by EGI Foundation, like
+`egi.eu`.
+
+Please refer to [documentation on requesting a certificate](./certificates).
+
 ### EGI.eu site
 
 Information about the EGI Federation activities is published on the

--- a/content/en/internal/collaboration-tools/certificates/_index.md
+++ b/content/en/internal/collaboration-tools/certificates/_index.md
@@ -22,6 +22,13 @@ Operators of central services can request two types of certificates:
 - robot email certificates, to be used as client certificate, to authenticate
   using X509 as a service.
 
+> In some specific cases, like for
+> [Cloud Compute providers](../../../providers/cloud-compute/) not having access
+> to an IGTF CA, it's possible for them to request a robot certificate, as an
+> IGTF certificate is required for sending accounting records.
+
+> You can contact scs-ra@egi.eu (or operations@egi.eu) if you need support.
+
 ## Requesting a new certificate
 
 Open a ticket to Collaboration Tools SU in [EGI Helpdesk](../../helpdesk),
@@ -37,8 +44,6 @@ providing:
   mentioning the desire to use the [ACME protocol](#using-acme-protocol).
 
 An operator will follow with the request, and help you getting the certificate.
-
-> You can contact scs-ra@egi.eu (or operations@egi.eu) if you need support.
 
 ## Retrieving certificates
 

--- a/content/en/internal/collaboration-tools/certificates/_index.md
+++ b/content/en/internal/collaboration-tools/certificates/_index.md
@@ -27,7 +27,7 @@ Operators of central services can request two types of certificates:
 > to an IGTF CA, it's possible for them to request a robot certificate, as an
 > IGTF certificate is required for sending accounting records.
 
-> You can contact scs-ra@egi.eu (or operations@egi.eu) if you need support.
+You can contact scs-ra@egi.eu (or operations@egi.eu) if you need support.
 
 ## Requesting a new certificate
 

--- a/content/en/internal/collaboration-tools/certificates/_index.md
+++ b/content/en/internal/collaboration-tools/certificates/_index.md
@@ -1,0 +1,163 @@
+---
+title: "Certificates"
+type: docs
+weight: 20
+description: Certificate provisioning
+---
+
+EGI Foundation is having access to a
+[GÉANT Trusted Certificate Service](https://wiki.geant.org/display/TCSNT/)
+subscription.
+
+Sectigo is the current Certificate Authority (CA) providing certificates to
+GÉANT TCS.
+
+This can be used to issue IGTF-trust (AKA eScience certificates) and
+public-trust certificates, for the domains managed by EGI Foundation, like
+`egi.eu`.
+
+Operators of central services can request two types of certificates:
+
+- host certificates, with public-trust, and optionally IGTF trust
+- robot email certificates, to be used as client certificate, to authenticate
+  using X509 as a service
+
+## Requesting a new certificate
+
+Open a ticket to Collaboration Tools SU in [EGI Helpdesk](../../helpdesk),
+providing:
+
+- Justification of the request.
+- FQDN of the service.
+- Mailing list to be used as contact address that will receive
+  [renewal notifications](#renewal-of-certificates).
+- A Certificate Signing Request, generated as documented
+  [below](creating-a-certificate-signing-request), or mentioning the desire to
+  use the [ACME protocol](#using-acme-protocol).
+
+> You can also contact scs-ra@egi.eu (or operations@egi.eu) if you need support.
+
+## Renewal of certificates
+
+Certificates are usually valid for one year. Auto-renewal of certificates is
+enabled by default, 30 days before expiration, notifications will be sent to the
+contact address provided when requesting the certificate.
+
+The notifications contains links allowing to renew the certificate.
+
+## Creating a Certificate Signing Request
+
+In order to get a certificate, Service Providers should create a Certificate
+Signing Request (CSR).
+
+In the CSR only the Common Name (CN) is important, it should be the (FQDN) of
+the service Most of other fields will be replaced by the CA while generating the
+certificate.
+
+It can be done via different ways, some are documented below.
+
+### Using a web application
+
+DigiCert provides an online
+[web application](https://www.digicert.com/easy-csr/openssl.htm).
+
+### Using CloudFalre cfssl tool
+
+It can be done with the `cfssl` tool from
+[CloudFlare](https://github.com/cloudflare/cfssl).
+
+```shell
+# Replace #FQDN# by the FQDN of the service
+$ cfssl genkey <(echo '{"hosts":["#FQDN#"],"CN"#FQDN#","key":{"algo":"rsa","size":4096}}')
+  | cfssljson -bare $FQDN.rsa
+```
+
+### Using OpenSSL
+
+It can be done using the following `OpenSSL` command (This will generate a
+password-protected key. Adding the `-nodes` option will disable password
+protection for the key, beware if using it.
+
+```shell
+$ openssl req -out CSR.csr -new -newkey rsa:4096 -keyout privateKey.key
+```
+
+### Using ACME protocol
+
+It is possible to automate the certificate request and renewal using the
+[ACME protocol](https://datatracker.ietf.org/doc/html/rfc8555) via
+[certbot](https://certbot.eff.org/) or similar tools.
+
+Two things should be considered:
+
+- it's not yet possible to get eScience/IGTF-trusted certificates, it's on the
+  roadmap but without any firm ETA.
+- it's using a different intermediate CA from Sectigo, not the usual GEANT one
+  used for TCS, but this shouldn't have much impact for generic/non-eScience
+  public services.
+
+The EGI SDIS team will have to create and register an ACME client ID for you.
+
+Once you will have the credential it should be possible to request a
+certificate, using the [standard certbot client](https://certbot.eff.org/), as
+documented below.
+
+#### Registering the client and saving the credentials locally
+
+This will interactively register your certbot client. Even if the ACME
+credentials are shared, only a given client is able to manage the certificates
+it requested. Email address is used for urgent renewal and security notices.
+This is preferred way if you need to get notifications on certificate expiration
+and if you are doing some manual management or testing.
+
+```shell
+sudo certbot register --no-eff-email \
+   --server https://acme.sectigo.com/v2/OV \
+   --eab-kid <EAB_KID> \
+   --eab-hmac-key <EAB_HMAC_KEY> \
+    --email <CONTACT_EMAIL>
+
+# Checking existing account
+sudo certbot show_account --server https://acme.sectigo.com/v2/OV
+
+# Unregistering an account
+# Beware: you won't any more be able to revoke certificate issued with the account
+sudo certbot unregister --server https://acme.sectigo.com/v2/OV
+```
+
+##### Requesting a certificate
+
+```shell
+sudo certbot certonly --standalone --non-interactive \
+   --server https://acme.sectigo.com/v2/OV \
+   --domain fakedomaindonotexist.egi.eu
+```
+
+##### Revoking a certificate
+
+```shell
+sudo certbot revoke \
+   --server https://acme.sectigo.com/v2/OV \
+   --cert-name fakedomaindonotexist.egi.eu
+```
+
+#### Registering and requesting a certificate all at once
+
+This is useful when you don't want interactive registration, like for one shot
+scripts. Email address is used for urgent renewal and security notices.
+
+> Apparently the notification to use this email is not visible in cert-manager,
+> and the first option with explicit registration may be safer to get the
+> notifications, if it's a required feature.
+
+```shell
+sudo certbot certonly --standalone --non-interactive --agree-tos \
+   --server https://acme.sectigo.com/v2/OV \
+   --eab-kid <EAB_KID> --eab-hmac-key <EAB_HMAC_KEY> \
+   --rsa-key-size 4096 \
+   --email <CONTACT_EMAIL> \
+   --domain fakedomaindonotexist.egi.eu
+```
+
+Other usual certbot options should also work. You may also be able to use other
+tools that can speak the ACME protocol, it should be standard.

--- a/content/en/internal/collaboration-tools/certificates/_index.md
+++ b/content/en/internal/collaboration-tools/certificates/_index.md
@@ -18,9 +18,9 @@ public-trust certificates, for the domains managed by EGI Foundation, like
 
 Operators of central services can request two types of certificates:
 
-- host certificates, with public-trust, and optionally IGTF trust
+- host certificates, with public-trust, and optionally IGTF trust.
 - robot email certificates, to be used as client certificate, to authenticate
-  using X509 as a service
+  using X509 as a service.
 
 ## Requesting a new certificate
 
@@ -28,16 +28,26 @@ Open a ticket to Collaboration Tools SU in [EGI Helpdesk](../../helpdesk),
 providing:
 
 - Justification of the request.
+- Type of certificate (host or robot).
 - FQDN of the service.
 - Mailing list to be used as contact address that will receive
-  [renewal notifications](#renewal-of-certificates).
-- A Certificate Signing Request, generated as documented
-  [below](#creating-a-certificate-signing-request), or mentioning the desire to
-  use the [ACME protocol](#using-acme-protocol).
+  [renewal notifications](#renewing-certificates).
+- For host certificates: a
+  [Certificate Signing Request](#creating-a-certificate-signing-request), or
+  mentioning the desire to use the [ACME protocol](#using-acme-protocol).
 
-> You can also contact scs-ra@egi.eu (or operations@egi.eu) if you need support.
+An operator will follow with the request, and help you getting the certificate.
 
-## Renewal of certificates
+> You can contact scs-ra@egi.eu (or operations@egi.eu) if you need support.
+
+## Retrieving certificates
+
+- Host certificates will be sent by email, you will receive a notification with
+  links allowing to download it.
+- For robot certificates, you will receive an invitation by email allowing to
+  generate and retrieve it.
+
+## Renewing certificates
 
 Certificates are usually valid for one year. Auto-renewal of certificates is
 enabled by default, 30 days before expiration, notifications will be sent to the
@@ -47,8 +57,8 @@ The notifications contains links allowing to renew the certificate.
 
 ## Creating a Certificate Signing Request
 
-In order to get a certificate, Service Providers should create a Certificate
-Signing Request (CSR).
+In order to get a certificate, Service Providers may be requested to send a
+Certificate Signing Request (CSR).
 
 In the CSR only the Common Name (CN) is important, it should be the (FQDN) of
 the service Most of other fields will be replaced by the CA while generating the

--- a/content/en/internal/collaboration-tools/certificates/_index.md
+++ b/content/en/internal/collaboration-tools/certificates/_index.md
@@ -133,24 +133,24 @@ This is preferred way if you need to get notifications on certificate expiration
 and if you are doing some manual management or testing.
 
 ```shell
-sudo certbot register --no-eff-email \
+$ sudo certbot register --no-eff-email \
    --server https://acme.sectigo.com/v2/OV \
    --eab-kid <EAB_KID> \
    --eab-hmac-key <EAB_HMAC_KEY> \
     --email <CONTACT_EMAIL>
 
 # Checking existing account
-sudo certbot show_account --server https://acme.sectigo.com/v2/OV
+$ sudo certbot show_account --server https://acme.sectigo.com/v2/OV
 
 # Unregistering an account
 # Beware: you won't any more be able to revoke certificate issued with the account
-sudo certbot unregister --server https://acme.sectigo.com/v2/OV
+$ sudo certbot unregister --server https://acme.sectigo.com/v2/OV
 ```
 
 ##### Requesting a certificate
 
 ```shell
-sudo certbot certonly --standalone --non-interactive \
+$ sudo certbot certonly --standalone --non-interactive \
    --server https://acme.sectigo.com/v2/OV \
    --domain fakedomaindonotexist.egi.eu
 ```
@@ -158,7 +158,7 @@ sudo certbot certonly --standalone --non-interactive \
 ##### Revoking a certificate
 
 ```shell
-sudo certbot revoke \
+$ sudo certbot revoke \
    --server https://acme.sectigo.com/v2/OV \
    --cert-name fakedomaindonotexist.egi.eu
 ```
@@ -173,7 +173,7 @@ scripts. Email address is used for urgent renewal and security notices.
 > notifications, if it's a required feature.
 
 ```shell
-sudo certbot certonly --standalone --non-interactive --agree-tos \
+$ sudo certbot certonly --standalone --non-interactive --agree-tos \
    --server https://acme.sectigo.com/v2/OV \
    --eab-kid <EAB_KID> --eab-hmac-key <EAB_HMAC_KEY> \
    --rsa-key-size 4096 \

--- a/content/en/internal/collaboration-tools/certificates/_index.md
+++ b/content/en/internal/collaboration-tools/certificates/_index.md
@@ -84,7 +84,7 @@ It can be done with the `cfssl` tool from
 ```shell
 # Replace #FQDN# by the FQDN of the service
 $ cfssl genkey <(echo '{"hosts":["#FQDN#"],"CN"#FQDN#","key":{"algo":"rsa","size":4096}}')
-  | cfssljson -bare $FQDN.rsa
+  | cfssljson -bare ##FQDN##.rsa
 ```
 
 ### Using OpenSSL

--- a/content/en/internal/collaboration-tools/certificates/_index.md
+++ b/content/en/internal/collaboration-tools/certificates/_index.md
@@ -32,7 +32,7 @@ providing:
 - Mailing list to be used as contact address that will receive
   [renewal notifications](#renewal-of-certificates).
 - A Certificate Signing Request, generated as documented
-  [below](creating-a-certificate-signing-request), or mentioning the desire to
+  [below](#creating-a-certificate-signing-request), or mentioning the desire to
   use the [ACME protocol](#using-acme-protocol).
 
 > You can also contact scs-ra@egi.eu (or operations@egi.eu) if you need support.

--- a/content/en/internal/collaboration-tools/certificates/_index.md
+++ b/content/en/internal/collaboration-tools/certificates/_index.md
@@ -90,12 +90,19 @@ $ cfssl genkey <(echo '{"hosts":["#FQDN#"],"CN"#FQDN#","key":{"algo":"rsa","size
 ### Using OpenSSL
 
 It can be done using the following `OpenSSL` command (This will generate a
-password-protected key. Adding the `-nodes` option will disable password
-protection for the key, beware if using it.
+password-protected key.
+
+You will be asked for various questions, but the only important ones are the
+Common Name (CN) and Subject Alternative Names (SAN) (in case you want to
+request a certificates covering different FQDNs), as other values will be
+overwritten by the CA.
 
 ```shell
 $ openssl req -out CSR.csr -new -newkey rsa:4096 -keyout privateKey.key
 ```
+
+> Adding the `-nodes` option will disable password protection for the key,
+> beware if using it.
 
 ### Using ACME protocol
 


### PR DESCRIPTION
Document certificate software provisioning for central services. I've documented this under the Collaboration Tools internal service, the SDTP is being updated and discussions are still to take place on the exact list of components. But until know, we can keep it here, unless anyone is having a better suggestion.

Documentation status:
- [X] issuing host certificates
- [x] issuing robot certificates