### PR TITLE
[Check-in] Add OP migration section in the end-user guide

### DIFF
--- a/content/en/providers/check-in/sp/_index.md
+++ b/content/en/providers/check-in/sp/_index.md
@@ -71,12 +71,13 @@ The integration follows a two-step process:
    registration requests require approval by an administrator. The review
    process for the demo environment involves primarily the technical aspects of
    the service configuration. However, moving the service to production requires
-   compliance with all the [eligibility criteria](#services-eligible-for-integration)
-   (see Step 2). The demo instance allows for testing authentication and
-   authorisation through the academic and social Identity Providers connected
-   to Check-in without affecting the production Check-in service. Note that
-   while the demo instance has identical functionality to the production
-   instance, no information is shared between the two systems.
+   compliance with all the
+   [eligibility criteria](#services-eligible-for-integration) (see Step 2). The
+   demo instance allows for testing authentication and authorisation through the
+   academic and social Identity Providers connected to Check-in without
+   affecting the production Check-in service. Note that while the demo instance
+   has identical functionality to the production instance, no information is
+   shared between the two systems.
    - You can also test new features of Check-in that are not available in
      production yet, by registering your Service Provider and testing
      integration with the **development** instance of Check-in. In the
@@ -1064,10 +1065,10 @@ by creating new Refresh Tokens issued by Keycloak.
 - If you have obtained Refresh Tokens using the EGI Check-in Token Portal,
   please check the following table:
 
-  | Issuer                   | Production environment            |
-  | ------------------------ | --------------------------------- |
-  | Keycloak                 | <https://aai.egi.eu/token>        |
-  | MITREid Connect (Legacy) | <https://aai.egi.eu/token-legacy> |
+  | Issuer                   | Production environment              |
+  | ------------------------ | ----------------------------------- |
+  | Keycloak                 | <https://aai.egi.eu/token-keycloak> |
+  | MITREid Connect (Legacy) | <https://aai.egi.eu/token>          |
 
 - If you have obtained Refresh Tokens using the oidc-agent, please use the
   following command:

--- a/content/en/users/aai/check-in/obtaining-tokens/oidc-agent/_index.md
+++ b/content/en/users/aai/check-in/obtaining-tokens/oidc-agent/_index.md
@@ -16,6 +16,9 @@ for managing OpenID Connect tokens developed by
 If you haven't installed oidc-agent in your system, please read the
 [installation guide](https://indigo-dc.gitbook.io/oidc-agent/installation).
 
+{{% alert title="Note" color="info" %}} Please make sure that you have installed
+the version 4.3.0 or later {{% /alert %}}
+
 Make sure that the `oidc-agent-service` is started by executing the command:
 
 ```shell

--- a/content/en/users/aai/check-in/obtaining-tokens/token-portal/_index.md
+++ b/content/en/users/aai/check-in/obtaining-tokens/token-portal/_index.md
@@ -40,3 +40,18 @@ follow the steps below:
    ![EGI Check-in Token Portal Refresh Token](check-in-token-refresh-token.png)
    1. The value of the Refresh Token
    2. The command to generate new Access Token using the Refresh Token
+
+## EGI Check-in OpenID Provider Migration
+
+Currently we are migrating EGI Check-in OpenID Provider to a new Authorization
+Server, as result the Refresh Tokens, that was issued by the legacy
+Authorization Server, will not be accepted by the new one and you won't be able
+to generate new Access Tokens. In this case you will need to create a new
+Refresh Token using the dedicated instance of EGI Check-in Token Portal, which
+is integrated with the new EGI Check-in OpenID Provider. In the following table
+you can find the URLs of each instance of EGI Check-in Token Portal:
+
+| EGI Check-in OpenID Provider Instances | EGI Check-in Token Portal Instances |
+| -------------------------------------- | ----------------------------------- |
+| EGI Check-in OpenID Provider - New     | <https://aai.egi.eu/token-keycloak> |
+| EGI Check-in OpenID Provider - Legacy  | <https://aai.egi.eu/token>          |

--- a/content/en/users/aai/check-in/obtaining-tokens/token-portal/_index.md
+++ b/content/en/users/aai/check-in/obtaining-tokens/token-portal/_index.md
@@ -43,13 +43,13 @@ follow the steps below:
 
 ## EGI Check-in OpenID Provider Migration
 
-Currently we are migrating EGI Check-in OpenID Provider to a new Authorization
-Server, as result the Refresh Tokens, that was issued by the legacy
-Authorization Server, will not be accepted by the new one and you won't be able
-to generate new Access Tokens. In this case you will need to create a new
-Refresh Token using the dedicated instance of EGI Check-in Token Portal, which
-is integrated with the new EGI Check-in OpenID Provider. In the following table
-you can find the URLs of each instance of EGI Check-in Token Portal:
+As of July 2022, we are migrating EGI Check-in OpenID Provider to a new Authorisation
+Server, as a result the Refresh Tokens, issued by the legacy Authorisation Server,
+will not be accepted by the new one and you won't be able to generate new Access
+Tokens with them. In this case you need to create a new Refresh Token using the
+environment-specific EGI Check-in Token Portal, which is integrated with the new
+EGI Check-in OpenID Provider. In the following table you can find the URLs of the
+various instances:
 
 | EGI Check-in OpenID Provider Instances | EGI Check-in Token Portal Instances |
 | -------------------------------------- | ----------------------------------- |


### PR DESCRIPTION
# Summary

This PR introduce the following changes:

- Add a section for the OP migration in the end-user guide
- Add note for the minimum required version of oidc-agent
