### PR TITLE
Update to node 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          # NodeJS 12 is maintained until 2022-04-30
-          node-version: "12.x"
+          # NodeJS 16 is maintained until 2023-09-11
+          node-version: "16.x"
 
       - name: Cache dependencies
         uses: actions/cache@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build with Hugo
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Fetch the Docsy theme
           submodules: recursive

--- a/.github/workflows/build_pr_preview.yml
+++ b/.github/workflows/build_pr_preview.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build with Hugo
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Fetch the Docsy theme
           submodules: recursive

--- a/.github/workflows/build_pr_preview.yml
+++ b/.github/workflows/build_pr_preview.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          # NodeJS 12 is maintained until 2022-04-30
-          node-version: "12.x"
+          # NodeJS 16 is maintained until 2023-09-11
+          node-version: "16.x"
 
       - name: Cache dependencies
         uses: actions/cache@v1

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Make sure the actual branch is checked out when running on PR
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/delete_pr_preview.yml
+++ b/.github/workflows/delete_pr_preview.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build with Hugo
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: "pr_previews"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          # NodeJS 12 is maintained until 2022-04-30
-          node-version: "12.x"
+          # NodeJS 16 is maintained until 2023-09-11
+          node-version: "16.x"
 
       - name: Cache dependencies
         uses: actions/cache@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.repository == 'EGI-Federation/documentation' }}
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Fetch the Docsy theme
           submodules: recursive

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Make sure the actual branch is checked out when running on PR
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Update to node 16, as node 12 is no more supported since April 2022.
Node 16 is the current LTS, supported till 2023-09-11.
Bump actions relying on node 12 to latest version.

References:
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ 
- https://github.com/nodejs/release#release-schedule
- https://github.com/actions/checkout/releases/tag/v3.0.0