### PR TITLE
GitHub actions: use updated octokit call

### DIFF
--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/github-script@v6.3.3
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -34,7 +34,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "pr"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -79,7 +79,7 @@ jobs:
             var issue_number = Number('${{steps.extract.outputs.pr_number}}');
             const output = `#### Documentation preview deployed!
             Available at https://docs.egi.eu/documentation/${issue_number}`;
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
GitHub actions: use updated octokit call.
This should fix issues with deploying pull request previews, as identified in #526 .
Tested in https://github.com/gwarf/documentation/actions/runs/3312681659/jobs/5469654742