### PR TITLE
[Check-in] Add section in migration guide about the HTTP 502 error

### DIFF
--- a/content/en/providers/check-in/sp/_index.md
+++ b/content/en/providers/check-in/sp/_index.md
@@ -1112,6 +1112,22 @@ To solve this, please make sure the that:
    the Keycloak based UserInfo Endpoint
 1. You have added the Access Token to the Authorization header of the request
 
+##### `502 Bad Gateway` error after redirecting back to the Service
+
+If you are using NGINX as a Reverse Proxy, and you are getting the following
+error message in the logs:
+
+> upstream sent too big header while reading response header from upstream
+
+Then you need to increase the size of the buffer by adding the following options
+in the vhost configuration:
+
+```shell
+proxy_buffers 4 256k;
+proxy_buffer_size 128k;
+proxy_busy_buffers_size 256k;
+```
+
 ## Integrating Science Gateways with RCauth for obtaining (proxy) certificates
 
 In order for Science Gateways (VO portals) to obtain RFC proxy certificates

--- a/content/en/users/aai/check-in/signup/_index.md
+++ b/content/en/users/aai/check-in/signup/_index.md
@@ -71,10 +71,6 @@ get started:
 1. After reviewing your request, click **Confirm** and re-authenticate yourself
    using the Identity Provider you selected before.
 
-1. In the case of the **Sign Up** registration, you need to wait for an EGI User
-   Sponsor to approve your request to join the EGI User Community. Upon
-   approval, EGI AAI will send you a notification email.
-
 Note: After your registration has been completed, you can manage your profile
 through the [EGI Account Registry portal](https://aai.egi.eu/registry).
 


### PR DESCRIPTION
# Summary

This PR indorduces the following changes:

- Add a section in the migration guide about the HTTP502 error
- Remove reference of sponsors in signup guide
