### PR TITLE
Documentation on using DIRC CLI via CVMFS

### DIFF
--- a/content/en/users/compute/orchestration/workload-manager/_index.md
+++ b/content/en/users/compute/orchestration/workload-manager/_index.md
@@ -158,7 +158,7 @@ Please use the command below on any Unix machine and send its output to\
 `dirac-support` `<AT>` `mailman.egi.eu`
 
 ```shell
-openssl x509 -in $HOME/.globus/usercert.pem -subject -noout
+$ openssl x509 -in $HOME/.globus/usercert.pem -subject -noout
 ```
 
 ### The EGI Workload Manager Web Portal
@@ -240,14 +240,14 @@ The easiest way to install the client is via
 installed in your machine, install the DIRAC CLI as follows:
 
 ```shell
-docker run -it -v $HOME:$HOME -e HOME=$HOME diracgrid/client:egi
+$ docker run -it -v $HOME:$HOME -e HOME=$HOME diracgrid/client:egi
 ```
 
 Once the client software is installed, it should be configured in order to
 access the EGI Workload Manager service:
 
 ```shell
-source /opt/dirac/bashrc
+$ source /opt/dirac/bashrc
 ```
 
 To proceed further a temporary proxy of the user certificate should be created.
@@ -384,7 +384,7 @@ StdOutput = "StdOut"; StdError = "StdErr"; OutputSandbox = {"StdOut","StdErr"};
 Submit the job:
 
 ```shell
-dirac-wms-job-submit test.jdl JobID = 53755998
+$ dirac-wms-job-submit test.jdl JobID = 53755998
 ```
 
 Check the job status:
@@ -436,7 +436,7 @@ After creation of JDL file the next step is to submit the job, using the
 command:
 
 ```shell
-dirac-wms-job-submit InputAndOuputSandbox.jdl JobID = XXXXXXXX
+$ dirac-wms-job-submit InputAndOuputSandbox.jdl JobID = XXXXXXXX
 ```
 
 #### List of supported VOs

--- a/content/en/users/compute/orchestration/workload-manager/_index.md
+++ b/content/en/users/compute/orchestration/workload-manager/_index.md
@@ -343,7 +343,7 @@ properties   : LimitedDelegation, GenericPilot, Pilot, NormalUser
 
 #### Access the client via CVMFS
 
-The DIRAC client may be accessed via CVMFS with the following tow command lines:
+The DIRAC client may be accessed via CVMFS with the following two command lines:
 
 ```shell
 $ source /cvmfs/dirac.egi.eu/dirac/bashrc_egi_dev

--- a/content/en/users/compute/orchestration/workload-manager/_index.md
+++ b/content/en/users/compute/orchestration/workload-manager/_index.md
@@ -341,6 +341,15 @@ username     : jdoe
 properties   : LimitedDelegation, GenericPilot, Pilot, NormalUser
 ```
 
+#### Access the client via CVMFS
+
+The DIRAC client may be accessed via CVMFS with the following tow command lines:
+
+```shell
+$ source /cvmfs/dirac.egi.eu/dirac/bashrc_egi_dev
+$ dirac-login --issuer=https://dirac.egi.eu/auth
+```
+
 #### Managing simple jobs
 
 <!-- markdownlint-disable line-length -->
@@ -447,7 +456,7 @@ dirac-wms-job-submit InputAndOuputSandbox.jdl JobID = XXXXXXXX
   [Advanced Job Management](https://dirac.readthedocs.io/en/latest/UserGuide/Tutorials/JobManagementAdvanced/index.html)
 - [Past tutorials](https://github.com/DIRACGrid/DIRAC/wiki/TutorialIHEP2013-11)
 
-#### Technical Support
+### Technical Support
 
 - DIRAC User Guide:
   [https://dirac.readthedocs.io/en/latest/UserGuide/](https://dirac.readthedocs.io/en/latest/UserGuide/)

--- a/content/en/users/compute/orchestration/workload-manager/_index.md
+++ b/content/en/users/compute/orchestration/workload-manager/_index.md
@@ -456,7 +456,7 @@ dirac-wms-job-submit InputAndOuputSandbox.jdl JobID = XXXXXXXX
   [Advanced Job Management](https://dirac.readthedocs.io/en/latest/UserGuide/Tutorials/JobManagementAdvanced/index.html)
 - [Past tutorials](https://github.com/DIRACGrid/DIRAC/wiki/TutorialIHEP2013-11)
 
-### Technical Support
+## Technical Support
 
 - DIRAC User Guide:
   [https://dirac.readthedocs.io/en/latest/UserGuide/](https://dirac.readthedocs.io/en/latest/UserGuide/)

--- a/content/en/users/dev-env/notebooks/integration/_index.md
+++ b/content/en/users/dev-env/notebooks/integration/_index.md
@@ -110,7 +110,7 @@ Note that inputs that point to a URL should be specified using the
 
 ## EGI-WMS (DIRAC)
 
-If you are using a Notebooks instance integrated with D4Science, you may access the DIRAC client via CVMFS with the following two command lines:
+If you are using a Notebooks instance integrated with EGI Workload Manager, you may access the DIRAC client via CVMFS with the following two command lines:
 
 ```shell
 $ source /cvmfs/dirac.egi.eu/dirac/bashrc_egi_dev

--- a/content/en/users/dev-env/notebooks/integration/_index.md
+++ b/content/en/users/dev-env/notebooks/integration/_index.md
@@ -110,7 +110,8 @@ Note that inputs that point to a URL should be specified using the
 
 ## EGI-WMS (DIRAC)
 
-If you are using a Notebooks instance integrated with EGI Workload Manager, you may access the DIRAC client via CVMFS with the following two command lines:
+If you are using a Notebooks instance integrated with EGI Workload Manager,
+you may access the DIRAC client via CVMFS with the following two command lines:
 
 ```shell
 $ source /cvmfs/dirac.egi.eu/dirac/bashrc_egi_dev

--- a/content/en/users/dev-env/notebooks/integration/_index.md
+++ b/content/en/users/dev-env/notebooks/integration/_index.md
@@ -108,7 +108,7 @@ print(execution.status)
 Note that inputs that point to a URL should be specified using the
 `ComplextDataInput` class as shown above.
 
-## EGI-WMS (DIRAC)
+## EGI Workload Manager (DIRAC)
 
 If you are using a Notebooks instance integrated with EGI Workload Manager,
 you may access the DIRAC client via CVMFS with the following two command lines:

--- a/content/en/users/dev-env/notebooks/integration/_index.md
+++ b/content/en/users/dev-env/notebooks/integration/_index.md
@@ -110,7 +110,7 @@ Note that inputs that point to a URL should be specified using the
 
 ## EGI-WMS (DIRAC)
 
-If you are using a Notebooks instance integrated with D4Science, you may access the DITAC client via CVMFS with the following tow command lines:
+If you are using a Notebooks instance integrated with D4Science, you may access the DITAC client via CVMFS with the following two command lines:
 
 ```shell
 $ source /cvmfs/dirac.egi.eu/dirac/bashrc_egi_dev

--- a/content/en/users/dev-env/notebooks/integration/_index.md
+++ b/content/en/users/dev-env/notebooks/integration/_index.md
@@ -60,6 +60,16 @@ fedcloud token check
 If the `fedcloud` command is not available, please follow the
 [getting started](../../../getting-started/cli) guide to get it.
 
+## EGI Workload Manager (DIRAC)
+
+If you are using a Notebooks instance integrated with [EGI Workload Manager](../../../compute/orchestration/workload-manager),
+you may access the DIRAC client via CVMFS with the following two command lines:
+
+```shell
+$ source /cvmfs/dirac.egi.eu/dirac/bashrc_egi_dev
+$ dirac-login --issuer=https://dirac.egi.eu/auth
+```
+
 ## D4Science
 
 If you are using a Notebooks instance integrated with D4Science, you can easily
@@ -107,16 +117,6 @@ print(execution.status)
 
 Note that inputs that point to a URL should be specified using the
 `ComplextDataInput` class as shown above.
-
-## EGI Workload Manager (DIRAC)
-
-If you are using a Notebooks instance integrated with EGI Workload Manager,
-you may access the DIRAC client via CVMFS with the following two command lines:
-
-```shell
-$ source /cvmfs/dirac.egi.eu/dirac/bashrc_egi_dev
-$ dirac-login --issuer=https://dirac.egi.eu/auth
-```
 
 ## Other third-party services
 

--- a/content/en/users/dev-env/notebooks/integration/_index.md
+++ b/content/en/users/dev-env/notebooks/integration/_index.md
@@ -108,6 +108,15 @@ print(execution.status)
 Note that inputs that point to a URL should be specified using the
 `ComplextDataInput` class as shown above.
 
+## EGI-WMS (DIRAC)
+
+If you are using a Notebooks instance integrated with D4Science, you may access the DITAC client via CVMFS with the following tow command lines:
+
+```shell
+$ source /cvmfs/dirac.egi.eu/dirac/bashrc_egi_dev
+$ dirac-login --issuer=https://dirac.egi.eu/auth
+```
+
 ## Other third-party services
 
 We are open for integration with other services that may be relevant for your

--- a/content/en/users/dev-env/notebooks/integration/_index.md
+++ b/content/en/users/dev-env/notebooks/integration/_index.md
@@ -110,7 +110,7 @@ Note that inputs that point to a URL should be specified using the
 
 ## EGI-WMS (DIRAC)
 
-If you are using a Notebooks instance integrated with D4Science, you may access the DITAC client via CVMFS with the following two command lines:
+If you are using a Notebooks instance integrated with D4Science, you may access the DIRAC client via CVMFS with the following two command lines:
 
 ```shell
 $ source /cvmfs/dirac.egi.eu/dirac/bashrc_egi_dev


### PR DESCRIPTION
Information added on the access to DIRAC client via CVMFS to document DIRAC-Notebook integration. 

# Summary
Changes in : 

- `content/en/users/compute/orchestration/workload-manager/_index.md`: added CVMFS information, changed the header level for **Technical Support** paragraph
- `content/en/users/dev-env/notebooks/integration/_index.md`: added CVMFS information
---


**Related issue :**

Answers JIRA ticket https://jira.egi.eu/browse/ACETA-142
