### PR TITLE
CODEOWNERS: remove Catalin, as discussed with him

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,12 +40,8 @@ content/en/users/training/ @glarocca
 # Tutorials
 content/en/users/tutorials/ @enolfc @sebastian-luna-valero
 
-# HTC-related services
-content/en/users/compute/content-distribution/ @CatalinCondurache
-content/en/users/compute/high-throughput-compute/ @CatalinCondurache
-
 # Workload Manager
-content/en/users/compute/orchestration/workload-manager/ @CatalinCondurache @enolfc
+content/en/users/compute/orchestration/workload-manager/ @enolfc
 
 # Check-in 
 content/en/users/aai/ @vardizzo-lab


### PR DESCRIPTION
CODEOWNERS: remove Catalin, as discussed with him.
Some people are configured as code owners but are not able to follow with the reviews, it's cleaner to remove them than having to force the merge.
Let me know if you think of other adjustments to do.

This should also unblock #535.
Close #68.
Close #105.