### PR TITLE
Remove fedcloudcli env var EGI_SITE

### DIFF
--- a/content/en/users/compute/cloud-compute/auth/_index.md
+++ b/content/en/users/compute/cloud-compute/auth/_index.md
@@ -117,19 +117,18 @@ simplify the discovery of projects.
 
 ```shell
 # Get a list of sites (also available in [AppDB](https://appdb.egi.eu))
-fedcloud site list
+$ fedcloud site list
 # Get list of projects that you are allowed to access
 # You can either specify the name of the account in your oidc-agent configuration
 # or directly a valid access token
-fedcloud endpoint projects --site=<name of the site> \
+$ fedcloud endpoint projects --site=<name of the site> \
          [--oidc-agent-account <account name>|--oidc-access-token <access token>]
 # You can also use environment variables for the configuration
-export EGI_SITE=<name of the site>
-export OIDC_ACCESS_TOKEN=<your access token>
-fedcloud endpoint projects
+$ export OIDC_ACCESS_TOKEN=<your access token>
+$ fedcloud endpoint projects
 # or with  oidc-agent
-export OIDC_AGENT_ACCOUNT=<account name>
-fedcloud enpoint projects
+$ export OIDC_AGENT_ACCOUNT=<account name>
+$ fedcloud enpoint projects
 ```
 
 ### Using the OpenStack API
@@ -138,14 +137,14 @@ Once you know which project to use, you can use your regular openstack cli
 commands for performing actual operations in the provider:
 
 ```shell
-fedcloud openstack image list --site <NAME_OF_SITE> --vo <NAME_OF_VO>
+$ fedcloud openstack image list --site <NAME_OF_SITE> --vo <NAME_OF_VO>
 ```
 
 For third-party tools that can use token based authentication in OpenStack, use
 the following command:
 
 ```shell
-export OS_TOKEN=$(fedcloud openstack --site <NAME_OF_SITE> --vo <NAME_OF_VO> \
+$ export OS_TOKEN=$(fedcloud openstack --site <NAME_OF_SITE> --vo <NAME_OF_VO> \
                   token issue -c id -f value)
 ```
 

--- a/content/en/users/compute/orchestration/ec3/developers/_index.md
+++ b/content/en/users/compute/orchestration/ec3/developers/_index.md
@@ -27,6 +27,8 @@ following process:
 * [RADL](https://github.com/grycap/ec3/tree/master/templates)
 
 {{% alert title="Note" color="info" %}} For more information please contact
-- Miguel Caballer: `micafer1 <at> upv.es`
-- Amanda Calatrav: `amcaar <at> i3m.upv.es`
+
+* Miguel Caballer: `micafer1 <at> upv.es`
+* Amanda Calatrav: `amcaar <at> i3m.upv.es`
+
 {{% /alert %}}

--- a/content/en/users/compute/orchestration/ec3/developers/_index.md
+++ b/content/en/users/compute/orchestration/ec3/developers/_index.md
@@ -26,7 +26,7 @@ following process:
 * [EC3 documentation](http://ec3.readthedocs.io/en/devel/templates.html)
 * [RADL](https://github.com/grycap/ec3/tree/master/templates)
 
-### Contacts
-
-* Miguel Caballer at: micafer1 `<at>` upv `<dot>` es
-* Amanda Calatrava at: amcaar `<at>` i3m `<dot>` upv `<dot>` es
+{{% alert title="Note" color="info" %}} For more information please contact
+- Miguel Caballer: `micafer1 <at> upv.es`
+- Amanda Calatrav: `amcaar <at> i3m.upv.es`
+{{% /alert %}}

--- a/content/en/users/data/storage/block-storage/_index.md
+++ b/content/en/users/data/storage/block-storage/_index.md
@@ -101,7 +101,7 @@ to set them once and reuse them with each command invocation.
 ```shell
 $ export EGI_SITE=IN2P3-IRES
 $ export EGI_VO=vo.access.egi.eu
-$ fedcloud openstack volume list
+$ fedcloud openstack volume list --site $EGI_SITE
 Site: IN2P3-IRES, VO: vo.access.egi.eu, command: volume list
 +---------------------------+--------+-----------+------+--------------------------------+
 | ID                        | Name   | Status    | Size | Attached to                    |
@@ -122,7 +122,7 @@ to set them once and reuse them with each command invocation.
 ```shell
 > set EGI_SITE=IN2P3-IRES
 > set EGI_VO=vo.access.egi.eu
-> fedcloud openstack volume list
+> fedcloud openstack volume list --site %EGI_SITE%
 Site: IN2P3-IRES, VO: vo.access.egi.eu, command: volume list
 +---------------------------+--------+-----------+------+--------------------------------+
 | ID                        | Name   | Status    | Size | Attached to                    |
@@ -143,7 +143,7 @@ to set them once and reuse them with each command invocation.
 ```powershell
 > $Env:EGI_SITE="IN2P3-IRES"
 > $Env:EGI_VO="vo.access.egi.eu"
-> fedcloud openstack volume list
+> fedcloud openstack volume list --site $Env:EGI_SITE
 Site: IN2P3-IRES, VO: vo.access.egi.eu, command: volume list
 +---------------------------+--------+-----------+------+--------------------------------+
 | ID                        | Name   | Status    | Size | Attached to                    |

--- a/content/en/users/data/storage/object-storage/_index.md
+++ b/content/en/users/data/storage/object-storage/_index.md
@@ -133,7 +133,7 @@ to set them once and reuse them with each command invocation.
 ```shell
 $ export EGI_SITE=IFCA-LCG2
 $ export EGI_VO=vo.access.egi.eu
-$ fedcloud openstack container list
+$ fedcloud openstack container list --site $EGI_SITE
 +------------------+
 | Name             |
 +------------------+
@@ -152,7 +152,7 @@ to set them once and reuse them with each command invocation.
 ```shell
 > set EGI_SITE=IN2P3-IRES
 > set EGI_VO=vo.access.egi.eu
-> fedcloud openstack container list
+> fedcloud openstack container list --site %EGI_SITE%
 +------------------+
 | Name             |
 +------------------+
@@ -171,7 +171,7 @@ to set them once and reuse them with each command invocation.
 ```powershell
 > $Env:EGI_SITE="IN2P3-IRES"
 > $Env:EGI_VO="vo.access.egi.eu"
-> fedcloud openstack container list
+> fedcloud openstack container list --site $Env:EGI_SITE
 +------------------+
 | Name             |
 +------------------+

--- a/content/en/users/getting-started/cli/_index.md
+++ b/content/en/users/getting-started/cli/_index.md
@@ -248,18 +248,19 @@ provider via option `--oidc-url`.
 
 {{% alert title="Note" color="info" %}} Remember to also set the identity
 provider's name accordingly for OpenStack commands, by using the option
-`--openstack-auth-provider`. {{% /alert %}}
+`--openstack-auth-provider`.{{% /alert %}}
 
 #### Environment variables
 
 Most of the FedCloud client options can be set via environment variables:
 
 {{% alert title="Tip" color="info" %}} To save a lot of time, set the frequently
-used options like site, VO, etc. using environment variables. {{% /alert %}}
+used options like access token, VO, etc. using environment variables.
+{{% /alert %}}
 
 {{% alert title="Tip" color="info" %}} When you want commands to work on all
-sites in the EGI infrastructure, use `ALL_SITES` for the `--site` parameter
-(pass it directly or via an environment variable). {{% /alert %}}
+sites in the EGI infrastructure, use `ALL_SITES` for the `--site` parameter.
+{{% /alert %}}
 
 | Environment variable    | Command-line option         | Default value                        |
 | ----------------------- | --------------------------- | ------------------------------------ |
@@ -272,7 +273,6 @@ sites in the EGI infrastructure, use `ALL_SITES` for the `--site` parameter
 | OPENSTACK_AUTH_PROTOCOL | `--openstack-auth-protocol` | openid                               |
 | OPENSTACK_AUTH_PROVIDER | `--openstack-auth-provider` | egi.eu                               |
 | OPENSTACK_AUTH_TYPE     | `--openstack-auth-type`     | v3oidcaccesstoken                    |
-| EGI_SITE                | `--site`                    |                                      |
 | EGI_VO                  | `--vo`                      |                                      |
 
 #### Getting help
@@ -319,7 +319,6 @@ Options:
                                   v3oidcaccesstoken]
   --openstack-auth-provider TEXT  Check-in identity provider  [default:
                                   egi.eu]
-  --site TEXT                     Name of the site or ALL_SITES  [required]
   --vo TEXT                       Name of the VO  [required]
   -i, --ignore-missing-vo         Ignore sites that do not support the VO
   -j, --json-output               Print output as a big JSON object
@@ -359,7 +358,7 @@ Run a command to get details of a project:
 ```shell
 $ export EGI_SITE=IISAS-FedCloud
 $ export EGI_VO=eosc-synergy.eu
-$ fedcloud site show-project-id
+$ fedcloud site show-project-id --site $EGI_SITE
 export OS_AUTH_URL="https://cloud.ui.savba.sk:5000/v3/";
 export OS_PROJECT_ID="51f736d36ce34b9ebdf196cfcabd24ee";
 ```
@@ -388,7 +387,7 @@ Run a command to get details of a project:
 ```shell
 > set EGI_SITE=IISAS-FedCloud
 > set EGI_VO=eosc-synergy.eu
-> fedcloud site show-project-id
+> fedcloud site show-project-id --site %EGI_SITE%
 set OS_AUTH_URL=https://cloud.ui.savba.sk:5000/v3/
 set OS_PROJECT_ID=51f736d36ce34b9ebdf196cfcabd24ee
 ```
@@ -416,9 +415,9 @@ OS_PROJECT_ID=51f736d36ce34b9ebdf196cfcabd24ee
 Run a command to get details of a project:
 
 ```powershell
-> $Env:EGI_SITE = "IISAS-FedCloud"
-> $Env:EGI_VO = "eosc-synergy.eu"
-> fedcloud site show-project-id
+> $Env:EGI_SITE="IISAS-FedCloud"
+> $Env:EGI_VO="eosc-synergy.eu"
+> fedcloud site show-project-id --site $Env:EGI_SITE
 $Env:OS_AUTH_URL="https://cloud.ui.savba.sk:5000/v3/";
 $Env:OS_PROJECT_ID="51f736d36ce34b9ebdf196cfcabd24ee";
 ```
@@ -426,7 +425,8 @@ $Env:OS_PROJECT_ID="51f736d36ce34b9ebdf196cfcabd24ee";
 Run the same command but set environment variables with the returned values:
 
 ```powershell
-> fedcloud site show-project-id | Out-String | Invoke-Expression
+> fedcloud site show-project-id --site $Env:EGI_SITE `
+                | Out-String | Invoke-Expression
 ```
 
 The environment variables will have their values set to what the command
@@ -458,7 +458,7 @@ using it to extract data from JSON sources. {{% /alert %}}
 ```shell
 $ export EGI_SITE=IISAS-FedCloud
 $ export EGI_VO=eosc-synergy.eu
-$ fedcloud openstack flavor list --json-output
+$ fedcloud openstack flavor list --site $EGI_SITE --json-output
 [
 {
   "Site": "IISAS-FedCloud",
@@ -491,7 +491,7 @@ $ fedcloud openstack flavor list --json-output
 ]
 
 # The following jq command selects flavors with VCPUs=2 and prints their names
-$ fedcloud openstack flavor list--json-output | \
+$ fedcloud openstack flavor list --site IISAS-FedCloud --json-output | \
     jq -r '.[].Result[] | select(.VCPUs == 2) | .Name'
 m1.medium
 ```
@@ -499,7 +499,7 @@ m1.medium
 {{% alert title="Note" color="info" %}} Note that `--json-output` option can be
 used only with those OpenStack commands that have outputs. Using this parameter
 with commands with no output (e.g. setting properties) will generate an
-unsupported parameter error. {{% /alert %}}
+unsupported parameter error.{{% /alert %}}
 
 <!--
 // jscpd:ignore-end

--- a/content/en/users/getting-started/task-force/_index.md
+++ b/content/en/users/getting-started/task-force/_index.md
@@ -51,7 +51,7 @@ The task force members:
 
 {{% alert title="Tip" color="info" %}} If you are interested in joining the
 EGI FedCloud Task Force, send an email to
-`fedcloud-tf` `<at>` `mailman.egi.eu` and introduce yourself.
+`fedcloud-tf <at> mailman.egi.eu` and introduce yourself.
 {{% /alert %}}
 
 {{% alert title="Note" color="info" %}} We hold bi-weekly meetings on Tuesdays

--- a/content/en/users/training/_index.md
+++ b/content/en/users/training/_index.md
@@ -95,4 +95,4 @@ The infrastructure currently includes enough capacity to scale up to
 class-room size audiences, approximately up to 100 participants.
 
 Do you want to book the infrastructure for a course? Please send a
-request through [our site](https://www.egi.eu/services/training-infrastructure/).
+request through [our site](https://www.egi.eu/service/training-infrastructure/).

--- a/content/en/users/training/_index.md
+++ b/content/en/users/training/_index.md
@@ -80,7 +80,7 @@ provider.
 {{% alert title="Join the training infrastructure!" color="info" %}}
 
 Do you want to join as a resource provider? Please email at
-`support _at_ egi.eu`.
+`support <at> egi.eu`.
 {{% /alert %}}
 
 The list of providers and VAs is also discoverable in the


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the [Contributing guide](https://docs.egi.eu/about/contributing/)
for style requirements and advice.
-->

# Summary

The FedCloud CLI was using an env var EGI_SITE to set the site on which to operate. This is not working since a while now, because of a bug in a Python lib. Details at https://github.com/tdviet/fedcloudclient/issues/150. 

Thus I removed this from our user docs, will update when a workaround is implemented in a new version of FedCloud CLI.