### PR TITLE
Fix syntax error in RADL file

### DIFF
--- a/content/en/users/compute/orchestration/im/cli/_index.md
+++ b/content/en/users/compute/orchestration/im/cli/_index.md
@@ -96,7 +96,7 @@ cpu.count>=2 and
 memory.size>=4g and
 net_interface.0.connection = 'public' and
 disk.0.os.name='linux' and
-disk.0.image.url = 'appdb://SCAI/egi.ubuntu.20.04?vo.access.egi.eu' and
+disk.0.image.url = 'appdb://SCAI/egi.ubuntu.20.04?vo.access.egi.eu'
 )
 
 configure wn (


### PR DESCRIPTION
Fix syntax error in RADL file, I wasn't able to deploy a VM using the code from the example.