### PR TITLE
Lint and spell only changed files to limit wast of resources.

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,7 +1,8 @@
 ---
 name: Check links
 
-on: [pull_request]
+on:
+  pull_request:
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,8 @@
 ---
 name: Lint
 
-on: [pull_request]
+on:
+  pull_request:
 
 jobs:
   super-lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,8 +27,8 @@ jobs:
           MARKDOWN_CONFIG_FILE: .markdownlint.json
           # XXX gitleaks is currently not using exception file: #511
           VALIDATE_GITLEAKS: false
-          # Always check all the content
-          VALIDATE_ALL_CODEBASE: true
+          # Only check changed files
+          VALIDATE_ALL_CODEBASE: false
           # Debug super-linter
           ACTIONS_RUNNER_DEBUG: false
           # Fail on errors

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -66,7 +66,7 @@ jobs:
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
-      cancel-in-progress: no
+      cancel-in-progress: false
     steps:
       - name: check-spelling
         id: spelling

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -66,7 +66,7 @@ jobs:
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
-      cancel-in-progress: true
+      cancel-in-progress: no
     steps:
       - name: check-spelling
         id: spelling
@@ -74,6 +74,7 @@ jobs:
         with:
           suppress_push_for_open_pull_request: 1
           checkout: true
+          only_check_changed_files: 1
           check_file_names: 1
           spell_check_this: check-spelling/spell-check-this@prerelease
           post_comment: 0


### PR DESCRIPTION
Lint and spell only changed files to limit wast of resources..

The codebase should already be in a sane situation, lint and spell checks have been running across all the codebase.