### PR TITLE
Prevent editorcondig-checker to look in markdown files

### DIFF
--- a/.github/linters/.ecrc
+++ b/.github/linters/.ecrc
@@ -1,0 +1,16 @@
+{
+  "Verbose": false,
+  "Debug": false,
+  "IgnoreDefaults": false,
+  "SpacesAfterTabs": false,
+  "NoColor": false,
+  "Exclude": ["\\.md$"],
+  "Disable": {
+    "EndOfLine": false,
+    "Indentation": false,
+    "InsertFinalNewline": false,
+    "TrimTrailingWhitespace": false,
+    "IndentSize": false,
+    "MaxLineLength": false
+  }
+}


### PR DESCRIPTION
Prevent editorcondig-checker to look in markdown files as it triggers too many false positives, cf #593 .
