### PR TITLE
Remove note about Keycloak migration from OIDC guide

### DIFF
--- a/content/en/providers/check-in/sp/_index.md
+++ b/content/en/providers/check-in/sp/_index.md
@@ -468,11 +468,6 @@ institutional IdPs registered with eduGAIN or Social Providers. Once the user
 has signed in, EGI Check-in can return OIDC Claims containing information about
 the authenticated user.
 
-{{% alert title="Important" color="warning" %}} The EGI Check-in OpenID Provider
-will be migrated to Keycloak. Please check
-[OIDC Client Migration to Keycloak](#client-migration-to-keycloak) for more
-details {{% /alert %}}
-
 ### Client registration
 
 Before your service can use the EGI Check-in OpenID Provider for user login, you


### PR DESCRIPTION
# Summary

This pull request removes the alert that warns users about the upcoming migration to Keycloak. The migration process has already been successfully executed, and this alert is no longer needed. By removing it, we ensure a streamlined user experience without unnecessary warnings to service owners/developers.