### PR TITLE
Fix lint-reported errors on GitHub actions

### DIFF
--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -4,3 +4,5 @@ extends: default
 rules:
   line-length:
     max: 120
+  truthy:
+    check-keys: false

--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -27,18 +27,18 @@ jobs:
         with:
           script: |
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
             });
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "pr"
             })[0];
             var download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
             });
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/pr.zip',

--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -42,7 +42,7 @@ jobs:
             });
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/pr.zip',
-                             Buffer.from(download.data));
+                              Buffer.from(download.data));
 
       - name: Extract pull request preview
         id: extract


### PR DESCRIPTION
Fix some lint-reported errors on GitHub actions.
By default yamllint will check keys for truthy: reporting useless errors, like for GitHub actions: https://yamllint.readthedocs.io/en/stable/rules.html#module-yam
llint.rules.truthy