### PR TITLE
Adding config for identity:list_users

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -485,6 +485,7 @@ processid
 promozione
 psnc
 puid
+PUIDs
 Putra
 pvc
 pycon

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -32,12 +32,12 @@ aso
 atl
 atnospam
 atrope
+Authtype
 autoprofixer
 avanzato
 azp
 backticks
 basemap
-bcdmi
 bcdmi
 bdii
 bdiis
@@ -61,6 +61,7 @@ calatrav
 calcolo
 caops
 cartopy
+CAs
 caso
 catania
 ccsrm
@@ -114,6 +115,7 @@ contextualized
 cou
 cous
 crls
+crt
 cryptsetup
 cscs
 csirt
@@ -184,6 +186,7 @@ emphasisproject
 enes
 enmr
 ente
+entitlements
 eosc
 epel
 eppn
@@ -287,6 +290,7 @@ iat
 ibergrid
 icecube
 idgrilles
+idp
 idps
 ifca
 igi
@@ -306,6 +310,7 @@ ipykernel
 ipynb
 irisgrid
 ismore
+iss
 itil
 janedoe
 jdl
@@ -401,6 +406,7 @@ NERGY
 netfilters
 neugrid
 ngi
+nginx
 ngis
 ngstat
 nic
@@ -417,7 +423,6 @@ nodiratime
 nokeys
 noout
 nordugrid
-nordugrid
 northgrid
 nostreams
 novaclient
@@ -428,6 +433,7 @@ nsupdate
 nsupdater
 nvidia
 OAIS
+oauth
 occi
 ODV
 ogf
@@ -447,6 +453,7 @@ onezone
 opencoast
 openidc
 opensaml
+openstack
 openstackclient
 oph
 ophuser
@@ -473,9 +480,11 @@ Politecnica
 postcss
 poweron
 poznan
+proactively
 processid
 promozione
 psnc
+puid
 Putra
 pvc
 pycon
@@ -525,6 +534,7 @@ seqnumber
 sfn
 sge
 SGs
+Shm
 shortcode
 shortcodes
 Simulink
@@ -548,6 +558,7 @@ srm
 srun
 ssds
 ssh
+ssl
 ssmsend
 STARTD
 stfc
@@ -664,6 +675,7 @@ wns
 workdir
 wps
 wroc
+WSGI
 WSL
 xacache
 xcache

--- a/content/en/providers/cloud-compute/openstack/aai.md
+++ b/content/en/providers/cloud-compute/openstack/aai.md
@@ -561,7 +561,7 @@ be granted permissions:
 
 Run:
 
-```bash
+```shell
 openstack mapping set --rules mapping.egi.json egi-mapping
 ```
 

--- a/content/en/providers/cloud-compute/openstack/aai.md
+++ b/content/en/providers/cloud-compute/openstack/aai.md
@@ -363,21 +363,9 @@ $ cat mapping.egi.json
 
 Create the mapping in Keystone:
 
-<!-- markdownlint-disable line-length -->
-
 ```shell
 $ openstack mapping create --rules mapping.egi.json egi-mapping
-+-------+--------------------------------------------------------------------------------------------------------------------------------------+
-| Field | Value                                                                                                                                |
-+-------+--------------------------------------------------------------------------------------------------------------------------------------+
-| id    | egi-mapping                                                                                                                          |
-| rules | [{u'remote': [{u'type': u'HTTP_OIDC_SUB'}, {u'type': u'HTTP_OIDC_ISS', u'any_one_of': [u'https://aai-demo.egi.eu/auth/realms/egi']}, |
-|       | {u'regex': True, u'type': u'OIDC-eduperson_entitlement', u'any_one_of': [u'^urn:mace:egi.eu:.*:ops:vm_operator@egi.eu$']}],          |
-|       | u'local': [{u'group': {u'id': u'89cf5b6708354094942d9d16f0f29f8f'}, u'user': {u'name': u'{0}'}}]}]                                   |
-+-------+--------------------------------------------------------------------------------------------------------------------------------------+
 ```
-
-<!-- markdownlint-enable line-length -->
 
 Finally, create the federated protocol with the identity provider and mapping
 created before:

--- a/content/en/providers/cloud-compute/openstack/aai.md
+++ b/content/en/providers/cloud-compute/openstack/aai.md
@@ -327,7 +327,7 @@ $ cat mapping.egi.json
                 ]
             }
         ]
-    }
+    },
     {
         "local": [
             {

--- a/content/en/providers/cloud-compute/openstack/aai.md
+++ b/content/en/providers/cloud-compute/openstack/aai.md
@@ -499,7 +499,7 @@ policy:
 
 Check the name:
 
-```bash
+```shell
 openstack domain show -f value -c name $(openstack identity provider show -f value -c domain_id egi.eu)
 ```
 

--- a/content/en/providers/cloud-compute/openstack/aai.md
+++ b/content/en/providers/cloud-compute/openstack/aai.md
@@ -452,7 +452,7 @@ resources.
 ### Additional VOs
 
 To configure additional VOs please follow steps in the
-[VO Configuration guide](../vo_config/).
+[VO Configuration guide](./vo_config/).
 
 ## Horizon Configuration
 

--- a/content/en/providers/cloud-compute/openstack/aai.md
+++ b/content/en/providers/cloud-compute/openstack/aai.md
@@ -473,7 +473,7 @@ members of `fedcloud.egi.eu`:
 ## VO cleaning
 
 Sometimes it is easy to leave behind Virtual Machines that are no longer used,
-consuming unncessary resources. Owners of unused VMs should be notified to
+consuming unnecessary resources. Owners of unused VMs should be notified to
 check whether occupied resources can be freed.
 
 EGI Check-in users get an `ePUID` (i.e. a long hash ending in `@egi.eu`) which


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
This description of the PR will be used as the commit message when merging it.
Ideally, there is an existing issue which the PR address.

Please check the [Contributing guide](https://docs.egi.eu/about/contributing/)
for style requirements and advice.
-->

# Summary

Configuration to enable permissions for EGI.eu staff to execute `openstack user list`.
This will allow EGI.eu staff to proactively notify creators of long-running VMs and free up resources accordingly.
Many thanks @astalosj and @enolfc for your help!

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
