### PR TITLE
Add required permissisons to deploy previews

### DIFF
--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -13,7 +13,9 @@ on:
     workflows: ["Build pull request preview"]
     types: [completed]
 
-permissions: read-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   deploy_pr_preview:


### PR DESCRIPTION
The actions should only be triggered when a label is set, and only selected users can set labels.

As per https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-pull-requests, `contents: write` should be required to push the content to the preview branch, and `pull-requests: write` should be required for writing the comment.