### PR TITLE
chore: adjust delete PR workflow name and set required permissions

### DIFF
--- a/.github/workflows/build_pr_preview.yml
+++ b/.github/workflows/build_pr_preview.yml
@@ -8,8 +8,7 @@ on:
     # Run when label is added or present and when pushing to the PR
     types: [labeled, opened, synchronize]
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   build_preview:

--- a/.github/workflows/delete_pr_preview.yml
+++ b/.github/workflows/delete_pr_preview.yml
@@ -16,7 +16,9 @@ jobs:
       ((github.event.action == 'unlabeled' && github.event.label.name == 'safe
       for preview') || (github.event.action == 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'safe for preview')))
-    name: Build with Hugo
+    name: Delete PR preview when a PR is closed or label removed
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I think the deletion of PR preview never works, let's see if we can get it working.