### PR TITLE
chore: remove useless parameter for EndBug/add-and-commit

### DIFF
--- a/.github/workflows/delete_pr_preview.yml
+++ b/.github/workflows/delete_pr_preview.yml
@@ -28,6 +28,5 @@ jobs:
       - name: Delete pull request preview and commit changes
         uses: EndBug/add-and-commit@v9
         with:
-          branch: "pr_previews"
           remove: "-r ${{ github.event.number }}/"
           message: "Purge preview for PR ${{ github.event.number }}"


### PR DESCRIPTION
The proper branch is checked out by the checkout action