### PR TITLE
chore: disable spell check workflow on push, only use it in PR

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -4,10 +4,7 @@
 name: MegaLinter
 
 on:
-  # Trigger mega-linter at every push. Action will also be visible from Pull Requests to main
-  push:
-    branches:
-      - "main"
+  # Trigger mega-linter only on PR against main branch
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -58,11 +58,6 @@ name: Check Spelling
 #     ... otherwise adjust the `with:` as you wish
 
 on:
-  push:
-    branches:
-      - "main"
-    tags-ignore:
-      - "**"
   pull_request_target:
     branches:
       - "main"

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -109,6 +109,7 @@ jobs:
             github.repository)) && 1 }}
           extra_dictionary_limit: 20
           extra_dictionaries: cspell:software-terms/dict/softwareTerms.txt
+          warnings: no-files-to-check
 
   comment-push:
     name: Report (Push)


### PR DESCRIPTION
There is no real need to spend cycles doing a spell check when pushing to main, especially if there won't be follow up on failures.