### PR TITLE
chore: ensure build is considered production to enable indexing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Build and minify using Hugo
         run: hugo --minify
+        env:
+          HUGO_ENV: production
 
       - name: Generate token for pushing content
         uses: tibdex/github-app-token@v2


### PR DESCRIPTION
Since some time I was wondering why no docs.egi.eu pages are present in Google search. I just made some verifications and just realised that until now the indexing by search engines is disabled due the presence of a meta tag in the source of the pages.

The [docsy theme](https://www.docsy.dev/) version we use relies on having a `HUGO_ENV` variable set: https://github.com/google/docsy/blob/f85c845226f30a4b2a55085d142e96def89e4c3f/layouts/partials/head.html#L10-L14

For the record a commit, added after the version we use changes this behaviour, thus this may have to be revised when updating the theme: https://github.com/google/docsy/commit/7e2e9298db9aa5866813e9ed17454b39aca81798
