### PR TITLE
configuration-database: Removing scope tags

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -81,6 +81,7 @@ cff
 cfg
 cfssl
 cfssljson
+checkbox
 chipster
 ciemat
 cilogon
@@ -98,6 +99,7 @@ cloudkey
 clouduser
 cmdb
 cmfs
+cms
 cmssw
 cnaf
 cnrs

--- a/content/en/internal/configuration-database/scopes/_index.md
+++ b/content/en/internal/configuration-database/scopes/_index.md
@@ -21,8 +21,7 @@ type: "docs"
   its service scopes plus any other site specific tags defined by the site.
 - By defining scope tags, resources can be ‘filtered-by-scope-tag’ when querying
   for data in the PI using the ‘scope’ and ‘scope_match’ parameters, see
-  [GOCDB Programmatic Interface (GOCDB-PI)](https://wiki.egi.eu/wiki/GOCDB/PI/Technical_Documentation)(link
-  to old EGI Wiki) for details.
+  [GOCDB Programmatic Interface](https://gocdb.github.io/api/n) for details.
 
 ## Clear Separation of Concerns
 

--- a/content/en/internal/configuration-database/scopes/_index.md
+++ b/content/en/internal/configuration-database/scopes/_index.md
@@ -21,7 +21,7 @@ type: "docs"
   its service scopes plus any other site specific tags defined by the site.
 - By defining scope tags, resources can be ‘filtered-by-scope-tag’ when querying
   for data in the PI using the ‘scope’ and ‘scope_match’ parameters, see
-  [GOCDB Programmatic Interface](https://gocdb.github.io/api/n) for details.
+  [GOCDB Programmatic Interface](https://gocdb.github.io/api/) for details.
 
 ## Clear Separation of Concerns
 

--- a/content/en/internal/configuration-database/scopes/_index.md
+++ b/content/en/internal/configuration-database/scopes/_index.md
@@ -85,6 +85,10 @@ It is important to understand that scopes and Projects are distinct:
   authorisation is given, please contact the Configuration Database admins with
   details of the approval (e.g. link to an [EGI Helpdesk](../../helpdesk) ticket
   that approves the tag assignment).
+- Users with a suitable role over a Site, or a Site's parent NGI can remove
+  reserved scope tags from their Site and its child Services. As part of
+  maintaining their Site information in GOCDB, Users should remove reserved
+  scope tags from their Sites and/or their Services when they cease to be relevant.
 
 ### FedCloud Reserved Tag
 


### PR DESCRIPTION
This PR updates the configuration database documentation around reserved scopes, specifically:
- adding a note that sites can (and should) remove reserved scope tags when they cease to be relevant
- fix link to old EGI wiki