### PR TITLE
chore: add allowed words dictionary to cspell

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -2,10 +2,14 @@
 language: "en-gb"
 dictionaries:
   - custom-words
+  - allowed-words
 ignorePaths:
   - ".github/actions/**"
   - ".cspell.json"
 dictionaryDefinitions:
   - name: custom-words
     path: ./.github/actions/spelling/expect.txt
+    addWords: true
+  - name: allowed-words
+    path: ./.github/actions/spelling/allow.txt
     addWords: true


### PR DESCRIPTION
# Summary

This adds the existing "allow.txt" list of words to the cspell configuration.

Note: there are two files configured for custom dictionaries (`allow.txt` and `expect.txt`)

These are a holdover from a time when the check-spelling action was used, this configuration is specific to that action. However since we cannot include the action in the pre-commit hooks, it was removed in favour of cspell.

**The word list configuration should be migrated to Cspell's.**

This will be done in a subsequent PR, but this should unblock people needing cspell to pass in pre-commit hooks.
