### PR TITLE
chore: ignore markdown codeblocks in spelling

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -17,6 +17,7 @@ languageSettings:
       - markdown_code_block
 ignorePaths:
   - ".github/actions/**"
+  - ".github/workflows/**"
   - ".cspell.json"
 dictionaryDefinitions:
   - name: custom-words

--- a/.cspell.yml
+++ b/.cspell.yml
@@ -3,6 +3,18 @@ language: "en-gb"
 dictionaries:
   - custom-words
   - allowed-words
+patterns:
+  - name: markdown_code_block
+    pattern: |
+      /
+          ^(\s*`{3,}).*     # match the ```
+          [\s\S]*?          # the block of code
+          ^\1               # end of the block
+      /gmx
+languageSettings:
+  - languageId: markdown
+    ignoreRegExpList:
+      - markdown_code_block
 ignorePaths:
   - ".github/actions/**"
   - ".cspell.json"

--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -1,13 +1,11 @@
 ---
 name: Deploy pull request preview
 # Setup and build files with hugo
-# cspell:disable-next-line
 # https://github.com/peaceiris/actions-hugo
 # Deploy to GitHub pages
 # https://github.com/peaceiris/actions-gh-pages
 # Triggered by the build pull request preview
 # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-
 on:
   # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run
   workflow_run:
@@ -109,7 +107,6 @@ jobs:
           - "security"
           - "training"
           - "tutorials"
-    # cspell:disable
     name: Check links of preview
     steps:
       - name: Checkout configuration
@@ -129,14 +126,12 @@ jobs:
         # to see if there are any bad links in those pages
         run: >-
           echo "https://docs.egi.eu/documentation/${{
-          job.deploy_pr_preview.outputs.pr_number }}/users/${{ matrix.url }}" |
+          github.event.pull_request.number }}/users/${{ matrix.url }}/" |
             ./hakrawler -u -i -d 10 -json |
             jq -r '. |
             select(.Source == "href") | .URL' |
             ./lychee -
   check_preview_links_internal:
-    env:
-      BASE_URL: https://docs.egi.eu/documentation/internal
     runs-on: ubuntu-latest
     needs:
       - deploy_pr_preview
@@ -177,15 +172,12 @@ jobs:
         # to see if there are any bad links in those pages
         run: >-
           echo "https://docs.egi.eu/documentation/${{
-          job.deploy_pr_preview.outputs.pr_number }}/internal/${{ matrix.url }}"
-          |
+          github.event.pull_request.number }}/internal/${{ matrix.url }}/" |
             ./hakrawler -u -i -d 10 -json |
             jq -r '. |
             select(.Source == "href") | .URL' |
             ./lychee -
   check_preview_links_providers:
-    env:
-      BASE_URL: https://docs.egi.eu/documentation/providers
     runs-on: ubuntu-latest
     needs:
       - deploy_pr_preview
@@ -225,34 +217,33 @@ jobs:
         # to see if there are any bad links in those pages
         run: >-
           echo "https://docs.egi.eu/documentation/${{
-          job.deploy_pr_preview.outputs.pr_number }}/providers/${{ matrix.url
-          }}" |
+          github.event.pull_request.number }}/providers/${{ matrix.url }}/" |
             ./hakrawler -u -i -d 10 -json |
             jq -r '. |
             select(.Source == "href") | .URL' |
             ./lychee -
   lychee-otherdocs: # cspell:disable-line
-    env:
-      BASE_URL: https://docs.egi.eu/
+    needs:
+      - deploy_pr_preview
     name: Check links at base of the about pages
     strategy:
       matrix:
-        url:
-          - ""
+        url: # do not include the root url, or we will crawl the whole site
           - about
           - support
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Get tools
-        # On the "other" page, we do not want to crawl down, so we only use
-        # lyuchee to check the page itself.
         run: |
           curl -fSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.19.1/lychee-x86_64-unknown-linux-musl.tar.gz | tar xvfz -> lychee
+          GOBIN=${PWD} go install github.com/hakluke/hakrawler@latest
       - name: Check Links.
-        run:
-          ./lychee https://docs.egi.eu/documentation/${{
-          job.deploy_pr_preview.outputs.pr_number }}/${{ matrix.url }}
-  # cspell:enable
+        run: >-
+          echo "https://docs.egi.eu/documentation/${{
+          github.event.pull_request.number }}/${{ matrix.url }}/" |
+            ./hakrawler -u -i -d 10 -json |
+            jq -r '. |
+            select(.Source == "href") | .URL' |
+            ./lychee -

--- a/.github/workflows/link-health-check.yml
+++ b/.github/workflows/link-health-check.yml
@@ -45,7 +45,7 @@ jobs:
         # and the resulting list is sent to lyuchee via stdin (-)
         # to see if there are any bad links in those pages
         run: >-
-          echo "${{ env.BASEURL }}/${{ matrix.url }}" |
+          echo "${{ env.BASEURL }}/${{ matrix.url }}/" |
             ./hakrawler -u -i -d 10 -json |
             jq -r '. |
             select(.Source == "href") | .URL' |
@@ -86,7 +86,7 @@ jobs:
         # and the resulting list is sent to lyuchee via stdin (-)
         # to see if there are any bad links in those pages
         run: >-
-          echo "${{ env.BASEURL }}/${{ matrix.url }}" |
+          echo "${{ env.BASEURL }}/${{ matrix.url }}/" |
             ./hakrawler -u -i -d 10 -json |
             jq -r '. |
             select(.Source == "href") | .URL' |
@@ -128,7 +128,7 @@ jobs:
         # and the resulting list is sent to lyuchee via stdin (-)
         # to see if there are any bad links in those pages
         run: >-
-          echo "${{ env.BASEURL }}/${{ matrix.url }}" |
+          echo "${{ env.BASEURL }}/${{ matrix.url }}/" |
             ./hakrawler -u -i -d 10 -json |
             jq -r '. |
             select(.Source == "href") | .URL' |
@@ -154,5 +154,5 @@ jobs:
         run: |
           curl -fSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.19.1/lychee-x86_64-unknown-linux-musl.tar.gz | tar xvfz -> lychee
       - name: Check Links.
-        run: ./lychee https://docs.egi.eu/${{ matrix.url }}
+        run: ./lychee https://docs.egi.eu/${{ matrix.url }}/
 # cspell:enable


### PR DESCRIPTION
# Summary

We are using CSpell to spell check the content.
It is reasonable to disable spell checking for markdown codeblocks, since maintaining words in these fenced blocks will create a lot of toil.

This adds a configuration to cspell to ignore codeblocks.

