### PR TITLE
ci(links): check the root of the area as well as sub-pages

### DIFF
--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -87,7 +87,9 @@ jobs:
             })
   check_preview_links_users:
     env:
-      BASE_URL: https://docs.egi.eu/documentation/users
+      BASE_URL:
+        https://docs.egi.eu/documentation/${{ github.event.pull_request.number
+        }}/users
     runs-on: ubuntu-latest
     needs:
       - deploy_pr_preview
@@ -98,15 +100,16 @@ jobs:
       matrix:
         # This matrix is built from the directories in content/en/users
         url:
-          - "aai"
-          - "compute"
-          - "data"
-          - "dev-env"
-          - "getting-started"
+          - /
+          - "/aai"
+          - "/compute"
+          - "/data"
+          - "/dev-env"
+          - "/getting-started"
           # - "machine-learning" # currently in draft
-          - "security"
-          - "training"
-          - "tutorials"
+          - "/security"
+          - "/training"
+          - "/tutorials"
     name: Check links of preview
     steps:
       - name: Checkout configuration
@@ -125,8 +128,7 @@ jobs:
         # and the resulting list is sent to lyuchee via stdin (-)
         # to see if there are any bad links in those pages
         run: >-
-          echo "https://docs.egi.eu/documentation/${{
-          github.event.pull_request.number }}/users/${{ matrix.url }}/" |
+          echo "${{ env.BASE_URL }}${{ matrix.url }}/" |
             ./hakrawler -u -i -d 10 -json |
             jq -r '. |
             select(.Source == "href") | .URL' |

--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -176,8 +176,8 @@ jobs:
         # and the resulting list is sent to lyuchee via stdin (-)
         # to see if there are any bad links in those pages
         run: >-
-          echo "https://docs.egi.eu/documentation/${{
-          github.event.pull_request.number }}/internal/${{ matrix.url }}/" |
+          echo "https://docs.egi.eu/documentation/${{ github.event.number
+          }}/internal/${{ matrix.url }}/" |
             ./hakrawler -u -i -d 10 -json |
             jq -r '. |
             select(.Source == "href") | .URL' |

--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -88,8 +88,8 @@ jobs:
   check_preview_links_users:
     env:
       BASE_URL:
-        https://docs.egi.eu/documentation/${{ github.event.pull_request.number
-        }}/users
+        https://docs.egi.eu/documentation/${{ needs.deploy_pr_preview.outputs.pr
+        _number }}/users
     runs-on: ubuntu-latest
     needs:
       - deploy_pr_preview
@@ -118,6 +118,7 @@ jobs:
         # We will run hakrawler to crawl a page and sub-pages
         # Then use lychee to check whether the urls in that page are ok.
         run: |
+          echo "${{ env.BASE_URL }}"
           curl -fSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.19.1/lychee-x86_64-unknown-linux-musl.tar.gz | tar xvfz -> lychee
           GOBIN=${PWD} go install github.com/hakluke/hakrawler@latest
       - name: Extract links and check them.

--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -18,6 +18,8 @@ permissions:
 
 jobs:
   deploy_pr_preview:
+    needs:
+      - build
     # Only run if PR preview build was successful
     if: >
       github.event.workflow_run.event == 'pull_request' &&

--- a/.github/workflows/link-health-check.yml
+++ b/.github/workflows/link-health-check.yml
@@ -19,15 +19,16 @@ jobs:
       matrix:
         # This matrix is built from the directories in content/en/users
         url:
-          - "aai"
-          - "compute"
-          - "data"
-          - "dev-env"
-          - "getting-started"
+          - /
+          - "/aai"
+          - "/compute"
+          - "/data"
+          - "/dev-env"
+          - "/getting-started"
           # - "machine-learning" # currently in draft
-          - "security"
-          - "training"
-          - "tutorials"
+          - "/security"
+          - "/training"
+          - "/tutorials"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -45,7 +46,7 @@ jobs:
         # and the resulting list is sent to lyuchee via stdin (-)
         # to see if there are any bad links in those pages
         run: >-
-          echo "${{ env.BASEURL }}/${{ matrix.url }}/" |
+          echo "${{ env.BASEURL }}${{ matrix.url }}/" |
             ./hakrawler -u -i -d 10 -json |
             jq -r '. |
             select(.Source == "href") | .URL' |
@@ -59,15 +60,16 @@ jobs:
       matrix:
         # This matrix is built from the directories in content/en/users
         url:
-          - "check-in"
-          - "cloud-compute"
-          - "datahub" # cspell:disable-line
-          - "high-throughput-compute"
-          - "joining"
-          - "notebooks"
-          - "online-storage"
-          - "operations-manuals"
-          - "rod"
+          - /
+          - "/check-in"
+          - "/cloud-compute"
+          - "/datahub" # cspell:disable-line
+          - "/high-throughput-compute"
+          - "/joining"
+          - "/notebooks"
+          - "/online-storage"
+          - "/operations-manuals"
+          - "/rod"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -86,7 +88,7 @@ jobs:
         # and the resulting list is sent to lyuchee via stdin (-)
         # to see if there are any bad links in those pages
         run: >-
-          echo "${{ env.BASEURL }}/${{ matrix.url }}/" |
+          echo "${{ env.BASEURL }}${{ matrix.url }}/" |
             ./hakrawler -u -i -d 10 -json |
             jq -r '. |
             select(.Source == "href") | .URL' |
@@ -100,16 +102,17 @@ jobs:
       matrix:
         # This matrix is built from the directories in content/en/users
         url:
-          - "accounting"
-          - "collaboration-tools"
-          - "configuration-database"
-          - "getting-started"
-          - "guidelines-software-development"
-          - "helpdesk" # cspell:disable-line
-          - "messaging"
-          - "monitoring"
-          - "operations-portal"
-          - "security-coordination"
+          - /
+          - "/accounting"
+          - "/collaboration-tools"
+          - "/configuration-database"
+          - "/getting-started"
+          - "/guidelines-software-development"
+          - "/helpdesk" # cspell:disable-line
+          - "/messaging"
+          - "/monitoring"
+          - "/operations-portal"
+          - "/security-coordination"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -128,21 +131,21 @@ jobs:
         # and the resulting list is sent to lyuchee via stdin (-)
         # to see if there are any bad links in those pages
         run: >-
-          echo "${{ env.BASEURL }}/${{ matrix.url }}/" |
+          echo "${{ env.BASEURL }}${{ matrix.url }}/" |
             ./hakrawler -u -i -d 10 -json |
             jq -r '. |
             select(.Source == "href") | .URL' |
             ./lychee -
   lychee-otherdocs: # cspell:disable-line
     env:
-      BASE_URL: https://docs.egi.eu/
+      BASE_URL: https://docs.egi.eu
     name: Check links at base of the about pages
     strategy:
       matrix:
         url:
-          - ""
-          - about
-          - support
+          - /
+          - /about
+          - /support
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -154,5 +157,5 @@ jobs:
         run: |
           curl -fSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.19.1/lychee-x86_64-unknown-linux-musl.tar.gz | tar xvfz -> lychee
       - name: Check Links.
-        run: ./lychee https://docs.egi.eu/${{ matrix.url }}/
+        run: ./lychee ${{ env.BASE_URL }}${{ matrix.url }}/
 # cspell:enable


### PR DESCRIPTION
# Summary

Update actions to include the root (`/`) of an area as well as the sub-pages

---


**Related issue :** #744 
