### PR TITLE
ci: remove spurious spaces in variable.

### DIFF
--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -90,8 +90,7 @@ jobs:
   check_preview_links_users:
     env:
       BASE_URL:
-        https://docs.egi.eu/documentation/${{ needs.deploy_pr_preview.outputs.pr
-        _number }}/users
+        https://docs.egi.eu/documentation/${{ needs.deploy_pr_preview.outputs.pr_number }}/users
     runs-on: ubuntu-latest
     needs:
       - deploy_pr_preview


### PR DESCRIPTION
# Summary

A spurious set of spaces was introduced to the deploy preview job.

---


**Related issue :** #751
