### PR TITLE
ci: remove dependency on build job

### DIFF
--- a/.github/workflows/deploy_pr_preview.yml
+++ b/.github/workflows/deploy_pr_preview.yml
@@ -18,8 +18,6 @@ permissions:
 
 jobs:
   deploy_pr_preview:
-    needs:
-      - build
     # Only run if PR preview build was successful
     if: >
       github.event.workflow_run.event == 'pull_request' &&


### PR DESCRIPTION
# Summary

Workflow actions require at least one job with no dependencies.  This workflow was declared to depend on the job "build pr preview" in another workflow, but that does not work for github actions. For now, the dependency has been removed, but in principle the build and deploy workflows should be combined.

**Related issue :** #751