### PR TITLE
chore: fix regexp escape for lychee ignore url line

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -18,4 +18,4 @@ https://voms2.hellasgrid.gr:8443/voms*
 https://www.eugridpma.org/your-identity/
 https://fts-egi.cern.ch:8446/
 https://fts-egi.cern.ch/fts3/ftsmon/
-https://confluence.ifca.es/spaces/IC/pages/1507347/Cloud+Compute+Flavors
+https://confluence.ifca.es/spaces/IC/pages/1507347/Cloud\+Compute\+Flavors


### PR DESCRIPTION
Closed #755

# Summary

Fix the `.lycheeignore` for urls with "+"

---


**Related issue :** #755 
