### PR TITLE
fix: add missing /users/ path in the vault HOME

### DIFF
--- a/content/en/users/security/secrets-store/cli/_index.md
+++ b/content/en/users/security/secrets-store/cli/_index.md
@@ -232,7 +232,7 @@ $ fedcloud secret put certificate @certificate.json \
 To delete values from an existing secret:
 
 ```shell
-$ fedcloud secret get certificate -f json | 
+$ fedcloud secret get certificate -f json |
             jq 'del (.another_cert, .another_key)' \
             > certificate.json
 $ fedcloud secret put certificate @certificate.json
@@ -271,7 +271,7 @@ To add new values to an existing secret:
 To delete values from an existing secret:
 
 ```powershell
-$ fedcloud secret get certificate -f json | ` 
+$ fedcloud secret get certificate -f json | `
             jq 'del (.another_cert, .another_key)' `
             > certificate.json
 $ fedcloud secret put certificate @certificate.json
@@ -558,19 +558,19 @@ variable:
 {{< tabpanex >}} {{< tabx header="Mac / Linux" >}}
 
 ```shell
-$ export VAULT_HOME=/secrets/$(curl -X POST https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo -H "Authorization: Bearer $OIDC_ACCESS_TOKEN" | jq -r .voperson_id)
+$ export VAULT_HOME=/secrets/users/$(curl -X POST https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo -H "Authorization: Bearer $OIDC_ACCESS_TOKEN" | jq -r .voperson_id)
 ```
 
 {{< /tabx >}} {{< tabx header="Powershell" >}}
 
 ```powershell
-> $env:VAULT_HOME=/secrets/$(curl -X POST https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo -H "Authorization: Bearer $env:OIDC_ACCESS_TOKEN" | jq -r .voperson_id)
+> $env:VAULT_HOME=/secrets/users/$(curl -X POST https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo -H "Authorization: Bearer $env:OIDC_ACCESS_TOKEN" | jq -r .voperson_id)
 ```
 
 {{< /tabx >}} {{< tabx header="Windows" >}}
 
 ```shell
-> for /f "delims=" %a in ('curl -X POST https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo -H "Authorization: Bearer %OIDC_ACCESS_TOKEN%" ^| jq -r .voperson_id') do set VAULT_HOME="/secrets/%a"
+> for /f "delims=" %a in ('curl -X POST https://aai.egi.eu/auth/realms/egi/protocol/openid-connect/userinfo -H "Authorization: Bearer %OIDC_ACCESS_TOKEN%" ^| jq -r .voperson_id') do set VAULT_HOME="/secrets/users/%a"
 ```
 
 {{< /tabx >}}{{< /tabpanex >}}


### PR DESCRIPTION
Update `VAULT_HOME` to fix the path to the secrets.

I also had issues due to the fact that my `egi` account in my `oidc-agent` was not having the `voperson_id` scope, thus the `jq` call was not returning it.
The `voperson_id` scope is not mentioned in the upstream `oidc-agent` configuration for the EGI provider at https://indigo-dc.gitbook.io/oidc-agent/user/oidc-gen/provider/egi, that is linked from https://docs.egi.eu/users/getting-started/cli/#authentication.
And https://docs.egi.eu/users/aai/check-in/obtaining-tokens/oidc-agent/ is not mentioning it too.